### PR TITLE
fix: Remove duplicate getAdminContext function causing build errors

### DIFF
--- a/src/lib/board-context.ts
+++ b/src/lib/board-context.ts
@@ -186,18 +186,3 @@ export async function getArbContext(astro: RoleContextAstro): Promise<GetRoleCon
 
   return { env, session, effectiveRole };
 }
-
-/**
- * Get context for admin-only pages. Redirects if not admin.
- * Use for /portal/admin/* pages.
- */
-export async function getAdminContext(astro: BoardContextAstro): Promise<GetBoardContextResult> {
-  const result = await getBoardContext(astro);
-  if ('redirect' in result) return result;
-  if (!isAdminRole(result.effectiveRole)) {
-    if (result.effectiveRole === 'board' || result.effectiveRole === 'arb_board') return { redirect: '/portal/board' };
-    if (result.effectiveRole === 'arb') return { redirect: '/portal/arb' };
-    return { redirect: '/portal/dashboard' };
-  }
-  return result;
-}


### PR DESCRIPTION
## Problem

The build pipeline was failing with 6 TypeScript errors in `src/lib/board-context.ts`:

```
error ts(2552): Cannot find name 'GetBoardContextResult'
error ts(2304): Cannot find name 'BoardContextAstro'
error ts(2393): Duplicate function implementation (x2)
error ts(2323): Cannot redeclare exported variable (x2)
```

This prevented:
- ✗ `npm run build` from succeeding
- ✗ `npm run astro check` from passing
- ✗ Pre-commit hooks from completing
- ✗ CI/CD pipelines from deploying

## Root Cause

The `src/lib/board-context.ts` file contained a **duplicate `getAdminContext` function** at line 194:

```typescript
// Line 61: Correct implementation
export async function getAdminContext(astro: RoleContextAstro): Promise<GetRoleContextResult> {
  // ... proper implementation
}

// Line 194: Duplicate with undefined types (BROKEN)
export async function getAdminContext(astro: BoardContextAstro): Promise<GetBoardContextResult> {
  // ... duplicate code using non-existent types
}
```

The duplicate used undefined types (`BoardContextAstro`, `GetBoardContextResult`) that don't exist in the codebase, causing TypeScript compilation to fail.

## Solution

**Removed the duplicate function** (lines 190-203) completely. The proper implementation at line 61 remains and works correctly.

### Changes
- **1 file changed**: `src/lib/board-context.ts`
- **15 lines deleted**: Removed duplicate function and its doc comment
- **0 lines added**: No new code needed

## Verification

### Before Fix
```bash
$ npm run astro check
Result: 6 errors ✗
```

### After Fix
```bash
$ npm run astro check
Result: 0 errors ✓

$ npm run build
Build completed successfully ✓

$ git commit
Pre-commit hooks: All passed ✓
```

## Testing

- ✅ **Astro Check**: 0 errors (was 6 errors)
- ✅ **Build**: Successful completion
- ✅ **Pre-commit Hooks**: All passed
- ✅ **No Functional Impact**: Only removed duplicate/broken code

## Impact

### Positive
- ✅ Unblocks build pipeline
- ✅ Enables CI/CD to pass
- ✅ Fixes pre-commit hooks
- ✅ Prevents future TypeScript errors

### No Breaking Changes
- ✅ No API changes
- ✅ No functional changes
- ✅ No behavior changes
- ✅ Only removed dead code

## Related Issues

This fix addresses the build failures that were blocking:
- PR reviews requiring passing builds
- Deployment to production
- Development workflow with pre-commit hooks

## Files Changed

```diff
src/lib/board-context.ts
  - Removed duplicate getAdminContext function (lines 190-203)
  - Kept proper implementation at line 61
```

## Checklist

- [x] Build passes (`npm run build`)
- [x] Astro check passes (`npm run astro check`)
- [x] Pre-commit hooks pass
- [x] No functional changes
- [x] Duplicate code removed
- [x] TypeScript errors resolved

---

**Priority**: High - Fixes critical build pipeline issue
**Type**: Bug fix
**Impact**: Low risk - Only removes duplicate/broken code