### PR TITLE
ci: Allow Claude bot in GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -47,4 +48,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary
- Add `allowed_bots: 'claude'` configuration to both Claude GitHub Actions workflows
- Fixes "non-human actor" errors when Claude Code creates PRs or interacts with issues

## Changes
- `.github/workflows/claude.yml`: Added `allowed_bots: 'claude'`
- `.github/workflows/claude-code-review.yml`: Added `allowed_bots: 'claude'`

## Test plan
- [ ] Verify Claude Code can trigger workflows after this is merged
- [ ] Confirm no "non-human actor" errors appear in workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)