### PR TITLE
fix: Initialize complete database schema for E2E tests in CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Initialize local D1 database
         run: |
           npm run db:init:local
+          npm run db:phase3:local
+          npm run db:phase4:local
+          npm run db:phase5:local
           npm run db:route-permissions:local
-        continue-on-error: true
 
       - name: Start wrangler dev server
         run: npm run preview:test &
@@ -106,8 +108,10 @@ jobs:
       - name: Initialize local D1 database
         run: |
           npm run db:init:local
+          npm run db:phase3:local
+          npm run db:phase4:local
+          npm run db:phase5:local
           npm run db:route-permissions:local
-        continue-on-error: true
 
       - name: Start wrangler dev server
         run: npm run preview:test &


### PR DESCRIPTION
## Problem

E2E tests are failing in GitHub Actions CI with database errors:
- `table users has no column named phone: SQLITE_ERROR`
- `no such table: owners: SQLITE_ERROR`

See failed runs: https://github.com/dagint/clrhoa-site/pull/54

## Root Cause

The CI workflow only runs `npm run db:init:local` which creates the base `users` table, but doesn't run the phase migrations that add:
- `phone` and `sms_optin` columns to users
- `owners` table
- Other required tables

Additionally, `continue-on-error: true` caused the workflow to continue even when DB init failed.

## Solution

1. **Remove `continue-on-error: true`** - Fail fast if DB init fails
2. **Run phase migrations** in CI:
   - `npm run db:phase3:local` - Creates owners, vendors, etc.
   - `npm run db:phase4:local` - Creates meetings, maintenance
   - `npm run db:phase5:local` - Creates assessments
3. Applied to both jobs: `e2e-tests` and `smoke-tests`

## Testing

✅ Local tests passing (10/10 smoke tests)
✅ This fix ensures CI has the same database schema as local

## Files Changed

- `.github/workflows/e2e-tests.yml` - Add phase migrations to DB init step

---

**Fixes:** #54 (CI failures)
**Related:** #55 (Auth schema - will add more migrations in future)