### PR TITLE
fix: Add missing phase 3.5 migration to E2E CI workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           npm run db:init:local
           npm run db:phase3:local
+          npm run db:phase35:local
           npm run db:phase4:local
           npm run db:phase5:local
           npm run db:route-permissions:local
@@ -109,6 +110,7 @@ jobs:
         run: |
           npm run db:init:local
           npm run db:phase3:local
+          npm run db:phase35:local
           npm run db:phase4:local
           npm run db:phase5:local
           npm run db:route-permissions:local


### PR DESCRIPTION
## Problem

E2E tests were failing in CI with:
```
table users has no column named phone: SQLITE_ERROR
```

## Root Cause

The CI workflow was running these migrations:
1. ✅ `db:init:local` (base schema)
2. ✅ `db:phase3:local` (directory, vendors)
3. ❌ **MISSING:** `db:phase35:local` (user phone/sms columns)
4. ✅ `db:phase4:local` (meetings)
5. ✅ `db:phase5:local` (assessments, feedback)
6. ✅ `db:route-permissions:local` (RBAC routes)

The E2E test setup tries to insert test users with `phone` and `sms_optin` columns, but these columns are added in `schema-phase35-users-notifications.sql` which was not being run.

## Solution

Added `npm run db:phase35:local` to the database initialization step in both:
- `e2e-tests` job
- `smoke-tests` job

## Changes

```diff
  - name: Initialize local D1 database
    run: |
      npm run db:init:local
      npm run db:phase3:local
+     npm run db:phase35:local
      npm run db:phase4:local
      npm run db:phase5:local
      npm run db:route-permissions:local
```

## Testing

This PR should fix the E2E test failures. The workflow will now:
1. Create the complete database schema including phone/sms_optin columns
2. Successfully seed test users with all required fields
3. E2E tests should pass ✅

## Related

- Follow-up to #56 (previous E2E CI database fix)
- Affects all E2E test runs (both full and smoke tests)

## Verification

After merge, check that:
- [ ] E2E tests pass in CI
- [ ] Smoke tests pass in CI
- [ ] No more "table users has no column named phone" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)