### PR TITLE
feat: Add Change Password UI for Authenticated Users (PR #14)

### DIFF
--- a/src/pages/api/auth/change-password.ts
+++ b/src/pages/api/auth/change-password.ts
@@ -1,0 +1,340 @@
+/**
+ * POST /api/auth/change-password
+ *
+ * Change password for authenticated user.
+ * User must provide current password for verification.
+ *
+ * Flow:
+ * 1. Verify user is authenticated
+ * 2. Validate current password
+ * 3. Validate new password meets requirements
+ * 4. Hash new password
+ * 5. Update password_hash and password_changed_at
+ * 6. Optionally revoke other sessions (not current one)
+ * 7. Send confirmation email
+ * 8. Log security event
+ *
+ * Security:
+ * - Requires valid session (authenticated users only)
+ * - Verifies current password before allowing change
+ * - Rate limiting prevents brute force (10 attempts per hour)
+ * - Password change is logged to security_events
+ * - Confirmation email sent to user
+ * - Current session is preserved, optionally revoke other sessions
+ *
+ * Response:
+ * - 200: Password changed successfully
+ * - 400: Invalid request (missing fields, weak password, passwords match)
+ * - 401: Unauthorized (no session or current password incorrect)
+ * - 429: Rate limit exceeded
+ * - 500: Server error
+ */
+
+import type { APIRoute } from 'astro';
+import { hashPassword, verifyPassword } from '../../../lib/password';
+import { logSecurityEvent } from '../../../lib/audit-log';
+import { checkRateLimit } from '../../../lib/rate-limit';
+import { createLucia } from '../../../lib/lucia';
+import { getUserByEmail } from '../../../lib/db';
+
+// Password validation constants
+const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 128;
+
+interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+  revokeOtherSessions?: boolean; // Optional: revoke all other sessions
+}
+
+interface ChangePasswordResponse {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Validate password meets security requirements
+ */
+function validatePassword(password: string): { valid: boolean; error?: string } {
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    return {
+      valid: false,
+      error: `Password must be at least ${MIN_PASSWORD_LENGTH} characters long`,
+    };
+  }
+
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return {
+      valid: false,
+      error: `Password must be no more than ${MAX_PASSWORD_LENGTH} characters long`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, locals, cookies }) => {
+  const db = locals.runtime?.env?.DB as D1Database | undefined;
+  const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const resend = locals.runtime?.env?.RESEND;
+  const session = locals.session;
+  const user = locals.user;
+
+  const ipAddress =
+    request.headers.get('CF-Connecting-IP') ||
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
+    'unknown';
+  const userAgent = request.headers.get('User-Agent') || 'unknown';
+
+  // 1. Verify user is authenticated
+  if (!session || !user || !db) {
+    return new Response(
+      JSON.stringify({ success: false, message: 'Unauthorized. Please log in.' } satisfies ChangePasswordResponse),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    // 2. Parse and validate request body
+    let body: ChangePasswordRequest;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ success: false, message: 'Invalid request format' } satisfies ChangePasswordResponse),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { currentPassword, newPassword, newPasswordConfirm, revokeOtherSessions = false } = body;
+
+    // Validate required fields
+    if (!currentPassword || !newPassword || !newPasswordConfirm) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: 'Current password, new password, and confirmation are required',
+        } satisfies ChangePasswordResponse),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Validate passwords match
+    if (newPassword !== newPasswordConfirm) {
+      return new Response(
+        JSON.stringify({ success: false, message: 'New passwords do not match' } satisfies ChangePasswordResponse),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Validate new password is different from current
+    if (currentPassword === newPassword) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: 'New password must be different from current password',
+        } satisfies ChangePasswordResponse),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Validate new password strength
+    const passwordValidation = validatePassword(newPassword);
+    if (!passwordValidation.valid) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: passwordValidation.error || 'Invalid password',
+        } satisfies ChangePasswordResponse),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // 3. Rate limiting - prevent brute force (10 attempts per hour per user)
+    const rateLimitResult = await checkRateLimit(
+      kv,
+      `/api/auth/change-password:${user.email}`,
+      ipAddress,
+      10, // max 10 attempts
+      60 * 60 // per hour
+    );
+
+    if (!rateLimitResult.allowed) {
+      await logSecurityEvent(db, {
+        eventType: 'password_change_rate_limit',
+        severity: 'warning',
+        userId: user.email,
+        details: {
+          ip_address: ipAddress,
+          reset_at: new Date(rateLimitResult.resetAt * 1000).toISOString(),
+        },
+      });
+
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: 'Too many password change attempts. Please try again later.',
+        } satisfies ChangePasswordResponse),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // 4. Get user from database (to verify current password)
+    const dbUser = await getUserByEmail(db, user.email);
+    if (!dbUser) {
+      return new Response(
+        JSON.stringify({ success: false, message: 'User not found' } satisfies ChangePasswordResponse),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Get password_hash from database
+    const passwordResult = await db
+      .prepare('SELECT password_hash FROM users WHERE email = ?')
+      .bind(user.email)
+      .first<{ password_hash: string | null }>();
+
+    if (!passwordResult?.password_hash) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: 'No password set. Please use password setup flow.',
+        } satisfies ChangePasswordResponse),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // 5. Verify current password
+    const isCurrentPasswordValid = await verifyPassword(passwordResult.password_hash, currentPassword);
+    if (!isCurrentPasswordValid) {
+      await logSecurityEvent(db, {
+        eventType: 'password_change_invalid_current_password',
+        severity: 'warning',
+        userId: user.email,
+        details: {
+          ip_address: ipAddress,
+          user_agent: userAgent,
+        },
+      });
+
+      return new Response(
+        JSON.stringify({ success: false, message: 'Current password is incorrect' } satisfies ChangePasswordResponse),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // 6. Hash new password
+    const newPasswordHash = await hashPassword(newPassword);
+
+    // 7. Update password in database
+    await db
+      .prepare(
+        `UPDATE users
+         SET password_hash = ?,
+             password_changed_at = CURRENT_TIMESTAMP,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE email = ?`
+      )
+      .bind(newPasswordHash, user.email)
+      .run();
+
+    // 8. Optionally revoke other sessions (not current one)
+    if (revokeOtherSessions && session.id) {
+      const lucia = createLucia(db);
+
+      // Get all sessions for this user
+      const allSessions = await db
+        .prepare('SELECT id FROM sessions WHERE user_id = ?')
+        .bind(user.email)
+        .all<{ id: string }>();
+
+      // Revoke all except current session
+      if (allSessions.results) {
+        for (const sess of allSessions.results) {
+          if (sess.id !== session.id) {
+            await lucia.invalidateSession(sess.id);
+          }
+        }
+      }
+
+      await logSecurityEvent(db, {
+        eventType: 'other_sessions_revoked',
+        severity: 'info',
+        userId: user.email,
+        details: {
+          reason: 'password_change',
+          ip_address: ipAddress,
+          session_count: allSessions.results?.length || 0,
+        },
+      });
+    }
+
+    // 9. Log successful password change
+    await logSecurityEvent(db, {
+      eventType: 'password_changed',
+      severity: 'info',
+      userId: user.email,
+      sessionId: session.id,
+      details: {
+        ip_address: ipAddress,
+        user_agent: userAgent,
+        revoked_other_sessions: revokeOtherSessions,
+      },
+    });
+
+    // 10. Send confirmation email (optional but recommended)
+    try {
+      await (resend as any)?.emails?.send({
+        from: 'CLRHOA Portal <portal@clrhoa.com>',
+        to: user.email,
+        subject: 'Your password has been changed',
+        html: `
+          <p>Hi ${dbUser.name || 'there'},</p>
+          <p>Your CLRHOA portal password has been successfully changed.</p>
+          <p>If you did not make this change, please contact support immediately at <a href="mailto:support@clrhoa.com">support@clrhoa.com</a>.</p>
+          ${revokeOtherSessions ? '<p>For security, all your other active sessions have been logged out.</p>' : ''}
+          <p>Thanks,<br>CLRHOA Team</p>
+        `,
+        text: `Hi ${dbUser.name || 'there'},\n\nYour CLRHOA portal password has been successfully changed.\n\nIf you did not make this change, please contact support immediately at support@clrhoa.com.\n\n${revokeOtherSessions ? 'For security, all your other active sessions have been logged out.\n\n' : ''}Thanks,\nCLRHOA Team`,
+      });
+    } catch (emailError) {
+      // Log but don't fail the request
+      console.error('Failed to send password change confirmation email:', emailError);
+    }
+
+    // 11. Return success response
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Password changed successfully',
+      } satisfies ChangePasswordResponse),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (error) {
+    console.error('Password change error:', error);
+
+    await logSecurityEvent(db, {
+      eventType: 'password_change_error',
+      severity: 'critical',
+      userId: user?.email,
+      details: {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        ip_address: ipAddress,
+      },
+    });
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        message: 'An error occurred while changing password. Please try again.',
+      } satisfies ChangePasswordResponse),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+};

--- a/src/pages/portal/profile/change-password.astro
+++ b/src/pages/portal/profile/change-password.astro
@@ -1,0 +1,272 @@
+---
+/**
+ * Change Password Page
+ *
+ * Allows authenticated users to change their password.
+ * Requires current password for verification.
+ */
+import PortalLayout from '../../../layouts/PortalLayout.astro';
+import ProtectedPage from '../../../components/ProtectedPage.astro';
+
+export const prerender = false;
+
+const env = Astro.locals.runtime?.env;
+const session = Astro.locals.session;
+
+// Redirect if not authenticated
+if (!session) return Astro.redirect('/portal/login');
+---
+
+<PortalLayout title="Change Password | Member Portal | Crooked Lake Reserve HOA">
+  <ProtectedPage>
+  <div class="portal-theme-bg min-h-screen">
+    <main class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <!-- Header -->
+      <div class="mb-8">
+        <a
+          href="/portal/profile/security"
+          class="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 mb-4"
+        >
+          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+          </svg>
+          Back to Security Settings
+        </a>
+
+        <h1 class="text-3xl font-bold text-gray-900">Change Password</h1>
+        <p class="text-gray-600 mt-2">Update your account password</p>
+      </div>
+
+      <!-- Messages -->
+      <div id="success-message" class="hidden mb-6 bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg">
+        <p class="font-medium"></p>
+      </div>
+
+      <div id="error-message" class="hidden mb-6 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg">
+        <p class="font-medium"></p>
+      </div>
+
+      <!-- Change Password Form -->
+      <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <form id="change-password-form" class="space-y-6">
+          <!-- Current Password -->
+          <div>
+            <label for="current-password" class="block text-sm font-medium text-gray-700 mb-2">
+              Current Password
+            </label>
+            <input
+              type="password"
+              id="current-password"
+              name="currentPassword"
+              required
+              autocomplete="current-password"
+              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              placeholder="Enter your current password"
+            />
+          </div>
+
+          <!-- New Password -->
+          <div>
+            <label for="new-password" class="block text-sm font-medium text-gray-700 mb-2">
+              New Password
+            </label>
+            <input
+              type="password"
+              id="new-password"
+              name="newPassword"
+              required
+              autocomplete="new-password"
+              minlength="8"
+              maxlength="128"
+              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              placeholder="Enter your new password"
+            />
+            <p class="text-sm text-gray-500 mt-1">
+              Must be at least 8 characters long
+            </p>
+          </div>
+
+          <!-- Confirm New Password -->
+          <div>
+            <label for="confirm-password" class="block text-sm font-medium text-gray-700 mb-2">
+              Confirm New Password
+            </label>
+            <input
+              type="password"
+              id="confirm-password"
+              name="newPasswordConfirm"
+              required
+              autocomplete="new-password"
+              minlength="8"
+              maxlength="128"
+              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              placeholder="Confirm your new password"
+            />
+          </div>
+
+          <!-- Revoke Other Sessions -->
+          <div class="flex items-start">
+            <div class="flex items-center h-5">
+              <input
+                type="checkbox"
+                id="revoke-sessions"
+                name="revokeOtherSessions"
+                class="w-4 h-4 text-green-600 border-gray-300 rounded focus:ring-green-500"
+              />
+            </div>
+            <div class="ml-3">
+              <label for="revoke-sessions" class="font-medium text-sm text-gray-700">
+                Log out other devices
+              </label>
+              <p class="text-sm text-gray-500">
+                End all other active sessions on other devices for security
+              </p>
+            </div>
+          </div>
+
+          <!-- Submit Button -->
+          <div class="flex items-center gap-4">
+            <button
+              type="submit"
+              id="submit-btn"
+              class="px-6 py-2 bg-clr-green text-white rounded-lg hover:bg-green-700 font-medium transition-colors focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+            >
+              Change Password
+            </button>
+
+            <a
+              href="/portal/profile/security"
+              class="px-6 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 font-medium transition-colors"
+            >
+              Cancel
+            </a>
+          </div>
+        </form>
+      </div>
+
+      <!-- Password Tips -->
+      <div class="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <h3 class="font-medium text-blue-900 mb-2">Password Tips</h3>
+        <ul class="text-sm text-blue-800 space-y-1 list-disc list-inside">
+          <li>Use a unique password that you don't use elsewhere</li>
+          <li>Include a mix of letters, numbers, and symbols</li>
+          <li>Avoid common words or personal information</li>
+          <li>Consider using a password manager</li>
+        </ul>
+      </div>
+    </main>
+  </div>
+  </ProtectedPage>
+</PortalLayout>
+
+<script>
+  interface ChangePasswordResponse {
+    success: boolean;
+    message: string;
+  }
+
+  const form = document.getElementById('change-password-form') as HTMLFormElement | null;
+  const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement | null;
+  const successMsg = document.getElementById('success-message') as HTMLDivElement | null;
+  const errorMsg = document.getElementById('error-message') as HTMLDivElement | null;
+
+  function showError(message: string): void {
+    if (!errorMsg || !successMsg) return;
+    errorMsg.querySelector('p')!.textContent = message;
+    errorMsg.classList.remove('hidden');
+    successMsg.classList.add('hidden');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function showSuccess(message: string): void {
+    if (!successMsg || !errorMsg) return;
+    successMsg.querySelector('p')!.textContent = message;
+    successMsg.classList.remove('hidden');
+    errorMsg.classList.add('hidden');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function hideMessages(): void {
+    if (!errorMsg || !successMsg) return;
+    errorMsg.classList.add('hidden');
+    successMsg.classList.add('hidden');
+  }
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    hideMessages();
+
+    const currentPassword = (document.getElementById('current-password') as HTMLInputElement)?.value;
+    const newPassword = (document.getElementById('new-password') as HTMLInputElement)?.value;
+    const newPasswordConfirm = (document.getElementById('confirm-password') as HTMLInputElement)?.value;
+    const revokeOtherSessions = (document.getElementById('revoke-sessions') as HTMLInputElement)?.checked ?? false;
+
+    // Client-side validation
+    if (!currentPassword || !newPassword || !newPasswordConfirm) {
+      showError('All fields are required');
+      return;
+    }
+
+    if (newPassword !== newPasswordConfirm) {
+      showError('New passwords do not match');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      showError('New password must be at least 8 characters long');
+      return;
+    }
+
+    if (currentPassword === newPassword) {
+      showError('New password must be different from current password');
+      return;
+    }
+
+    // Submit
+    if (!submitBtn) return;
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Changing password...';
+
+    try {
+      const response = await fetch('/api/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          currentPassword,
+          newPassword,
+          newPasswordConfirm,
+          revokeOtherSessions,
+        }),
+      });
+
+      const data = await response.json() as ChangePasswordResponse;
+
+      if (data.success) {
+        showSuccess(data.message || 'Password changed successfully!');
+        form?.reset();
+
+        // Redirect to security settings after 2 seconds
+        setTimeout(() => {
+          window.location.href = '/portal/profile/security';
+        }, 2000);
+      } else {
+        showError(data.message || 'Failed to change password. Please try again.');
+      }
+    } catch (error) {
+      console.error('Password change error:', error);
+      showError('An error occurred. Please try again.');
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Change Password';
+    }
+  });
+</script>
+
+<style>
+  .portal-theme-bg {
+    background-color: #f9fafb;
+  }
+  .bg-clr-green {
+    background-color: #1e5f38;
+  }
+</style>


### PR DESCRIPTION
## Summary
Implement password change functionality for logged-in users with current password verification and optional session revocation.

**Features:**
- ✅ Verify current password before allowing change
- ✅ Validate new password strength (min 8 characters)
- ✅ Prevent setting same password as current password
- ✅ Optional "log out other devices" checkbox to revoke other sessions
- ✅ Success message with auto-redirect to security settings
- ✅ Password tips and security best practices displayed
- ✅ Clean, user-friendly form interface

**API Endpoint:**
- `POST /api/auth/change-password`
  - Requires valid session (authenticated users only)
  - Verifies current password with bcrypt
  - Rate limiting: 10 attempts per hour per user
  - Logs password change to `security_events` table
  - Sends confirmation email notification
  - Optionally revokes other sessions (preserves current session)

**UI Page:**
- `/portal/profile/change-password`
  - Form with current/new/confirm password fields
  - Client-side validation for better UX
  - Type-safe fetch with response interface
  - Back link to security settings page
  - Password tips section

**Security:**
- Current password verification prevents unauthorized changes
- Rate limiting prevents brute force attacks
- Audit logging tracks all password changes with IP/user agent
- Email notification alerts user of password changes
- Current session preserved when revoking other sessions
- All changes logged to security events

**Related PRs:**
- PR #13: MFA Settings UI (links to this page from "Change Password" button)
- PR #12: Password-Based Login UI

## Test plan
- [x] Build succeeds without TypeScript errors
- [ ] Navigate to /portal/profile/security → click "Change Password"
- [ ] Enter current password, new password, confirm password
- [ ] Verify validation: passwords must match, min 8 chars, different from current
- [ ] Test "Log out other devices" checkbox functionality
- [ ] Verify success message and redirect to security settings
- [ ] Check confirmation email is sent
- [ ] Verify password change is logged to security_events

🤖 Generated with [Claude Code](https://claude.com/claude-code)