### PR TITLE
Fix: Auth endpoint theming and password reset API error

### DIFF
--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -42,6 +42,8 @@ function isValidEmail(email: string): boolean {
   return emailRegex.test(email);
 }
 
+export const prerender = false;
+
 export const POST: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB;
   const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;

--- a/src/pages/auth/forgot-password.astro
+++ b/src/pages/auth/forgot-password.astro
@@ -19,7 +19,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Forgot Password - CLRHOA Portal">
-  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 sm:px-6 lg:px-8">
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-emerald-100 px-4 sm:px-6 lg:px-8">
     <div class="max-w-md w-full space-y-8">
       <!-- Logo/Header -->
       <div class="text-center">
@@ -44,7 +44,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
                 type="email"
                 autocomplete="email"
                 required
-                class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-600 focus:border-green-600 sm:text-sm"
                 placeholder="you@example.com"
               />
             </div>
@@ -86,7 +86,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
             <button
               type="submit"
               id="submit-btn"
-              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"
+              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-600 transition-colors duration-200"
             >
               Send Reset Link
             </button>
@@ -97,7 +97,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
         <div class="mt-6 text-center">
           <a
             href="/auth/login"
-            class="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+            class="text-sm font-medium text-green-700 hover:text-green-800"
           >
             ← Back to Login
           </a>
@@ -107,7 +107,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
         <div class="mt-6 text-center">
           <p class="text-xs text-gray-500">
             Need help? Contact us at{' '}
-            <a href="mailto:support@clrhoa.com" class="text-indigo-600 hover:text-indigo-500">
+            <a href="mailto:support@clrhoa.com" class="text-green-700 hover:text-green-800">
               support@clrhoa.com
             </a>
           </p>
@@ -115,8 +115,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       </div>
 
       <!-- Security note -->
-      <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <p class="text-xs text-blue-800">
+      <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+        <p class="text-xs text-green-800">
           <strong>🔒 Security Note:</strong> For your protection, we'll only send reset emails to registered accounts.
           If you don't receive an email within a few minutes, check your spam folder or verify you're using the correct email address.
         </p>

--- a/src/pages/auth/reset-password.astro
+++ b/src/pages/auth/reset-password.astro
@@ -26,7 +26,7 @@ const hasToken = !!token;
 ---
 
 <BaseLayout title="Reset Your Password - CLRHOA Portal">
-  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 sm:px-6 lg:px-8">
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-emerald-100 px-4 sm:px-6 lg:px-8">
     <div class="max-w-md w-full space-y-8">
       <!-- Logo/Header -->
       <div class="text-center">
@@ -59,7 +59,7 @@ const hasToken = !!token;
                   required
                   minlength="8"
                   maxlength="128"
-                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-600 focus:border-green-600 sm:text-sm"
                   placeholder="At least 8 characters"
                 />
                 <button
@@ -105,7 +105,7 @@ const hasToken = !!token;
                   required
                   minlength="8"
                   maxlength="128"
-                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-600 focus:border-green-600 sm:text-sm"
                   placeholder="Re-enter your password"
                 />
               </div>
@@ -130,7 +130,7 @@ const hasToken = !!token;
               <button
                 type="submit"
                 id="submit-btn"
-                class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"
+                class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-600 transition-colors duration-200"
               >
                 Reset Password
               </button>
@@ -141,7 +141,7 @@ const hasToken = !!token;
           <div class="mt-6 text-center">
             <p class="text-xs text-gray-500">
               Need help? Contact us at{' '}
-              <a href="mailto:support@clrhoa.com" class="text-indigo-600 hover:text-indigo-500">
+              <a href="mailto:support@clrhoa.com" class="text-green-700 hover:text-green-800">
                 support@clrhoa.com
               </a>
             </p>
@@ -173,13 +173,13 @@ const hasToken = !!token;
           <div class="mt-6 space-y-3">
             <a
               href="/auth/forgot-password"
-              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-600"
             >
               Request New Reset Link
             </a>
             <a
               href="/auth/login"
-              class="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              class="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-600"
             >
               Back to Login
             </a>
@@ -189,8 +189,8 @@ const hasToken = !!token;
 
       <!-- Security note -->
       {hasToken && (
-        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <p class="text-xs text-blue-800">
+        <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+          <p class="text-xs text-green-800">
             <strong>🔒 Security Note:</strong> After resetting your password, all your active sessions will be logged out for security.
             You'll need to log in again with your new password.
           </p>

--- a/src/pages/auth/setup-password.astro
+++ b/src/pages/auth/setup-password.astro
@@ -26,7 +26,7 @@ const hasToken = !!token;
 ---
 
 <BaseLayout title="Set Up Your Password - CLRHOA Portal">
-  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 sm:px-6 lg:px-8">
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-emerald-100 px-4 sm:px-6 lg:px-8">
     <div class="max-w-md w-full space-y-8">
       <!-- Logo/Header -->
       <div class="text-center">
@@ -59,7 +59,7 @@ const hasToken = !!token;
                   required
                   minlength="8"
                   maxlength="128"
-                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-600 focus:border-green-600 sm:text-sm"
                   placeholder="At least 8 characters"
                 />
                 <button
@@ -105,7 +105,7 @@ const hasToken = !!token;
                   required
                   minlength="8"
                   maxlength="128"
-                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-600 focus:border-green-600 sm:text-sm"
                   placeholder="Re-enter your password"
                 />
               </div>
@@ -130,7 +130,7 @@ const hasToken = !!token;
               <button
                 type="submit"
                 id="submit-btn"
-                class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"
+                class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-600 transition-colors duration-200"
               >
                 Set Up Password
               </button>
@@ -141,7 +141,7 @@ const hasToken = !!token;
           <div class="mt-6 text-center">
             <p class="text-xs text-gray-500">
               Need help? Contact us at{' '}
-              <a href="mailto:support@clrhoa.com" class="text-indigo-600 hover:text-indigo-500">
+              <a href="mailto:support@clrhoa.com" class="text-green-700 hover:text-green-800">
                 support@clrhoa.com
               </a>
             </p>
@@ -173,7 +173,7 @@ const hasToken = !!token;
           <div class="mt-6">
             <a
               href="/auth/login"
-              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-600"
             >
               Go to Login
             </a>


### PR DESCRIPTION
## Summary
Fixes theming inconsistencies on auth pages and resolves 405 API error on password reset endpoint.

## Issues Fixed
1. **405 Method Not Allowed** error on `/api/auth/forgot-password` endpoint
2. Auth pages using blue/indigo colors instead of CLRHOA green theme

## Changes

### API Fix
- Added `export const prerender = false;` to `forgot-password.ts`
- Resolves 405 status and "SyntaxError: Unexpected end of JSON input" errors

### Theming Updates
Updated all auth pages to use consistent CLRHOA green color scheme:

**Pages Updated:**
- `forgot-password.astro`
- `setup-password.astro`
- `reset-password.astro`

**Color Mappings:**
- Backgrounds: `blue-50`/`indigo-100` → `green-50`/`emerald-100`
- Primary buttons: `indigo-600`/`700` → `green-700`/`800`
- Focus rings: `indigo-500` → `green-600`
- Links: `indigo-600` → `green-700`/`800`
- Info boxes: `blue-50`/`200`/`800` → `green-50`/`200`/`800`

## Design Decision
Semantic blue colors retained throughout the app for:
- Status badges (in review, pending)
- Informational boxes and tips
- Role indicators (arb_board)
- Permission level indicators

This maintains clear visual hierarchy: green = brand/actions, blue = info/neutral.

## Testing
- ✅ All pre-commit hooks passed
- ✅ Astro check passed
- [ ] Manual testing of password reset flow needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)