### PR TITLE
fix: Correct KV namespace binding name typo

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,7 +24,7 @@ database_id = "a214f9da-3577-4ee7-bc50-bc9b9754a79c"
 # KV: email whitelist (key = lowercase email, value = "1" or JSON { "role": "admin" })
 # id = the value printed when you ran: npx wrangler kv namespace create clrhoa_users
 [[kv_namespaces]]
-binding = "CLOURHOA_USERS"
+binding = "CLRHOA_USERS"
 id = "e936ea7760c04b268c4472eb24575d46"
 
 # Adapter expects SESSION KV. id = from: npx wrangler kv namespace create SESSION


### PR DESCRIPTION
## Issue
The login endpoint was returning 503 errors because the KV namespace binding name in wrangler.toml had a typo.

**Error:** `POST https://clrhoa.com/api/auth/login 503 (Service Unavailable)`

**Root cause:** The login API expects `CLRHOA_USERS` but wrangler.toml had `CLOURHOA_USERS` (extra 'O')

## Fix
- Changed `CLOURHOA_USERS` to `CLRHOA_USERS` in wrangler.toml line 27
- This matches what the login API expects in `src/pages/api/auth/login.ts:89`

## Testing
After deployment, login at https://clrhoa.com/auth/login should work correctly with credentials:
- Email: dagint@gmail.com  
- Password: (temp password set via database)

## Files Changed
- `wrangler.toml` (1 line change)