### PR TITLE
fix: Use wrangler CLI for deployment to apply wrangler.toml bindings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,14 +87,10 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_DEPLOY_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: clrhoa-site
-          directory: dist
-          # Git commit info for deployment
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        run: npx wrangler pages deploy dist --project-name=clrhoa-site --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_DEPLOY_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Sync Secrets to Cloudflare Pages
         if: success()

--- a/scripts/fix-users-table-for-lucia.sql
+++ b/scripts/fix-users-table-for-lucia.sql
@@ -1,0 +1,56 @@
+-- Fix users table to be compatible with Lucia
+-- Lucia expects an 'id' column as primary key
+
+-- Step 1: Create new users table with id column
+CREATE TABLE users_new (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  role TEXT DEFAULT 'member',
+  name TEXT,
+  created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  phone TEXT,
+  sms_optin INTEGER DEFAULT 0,
+  notification_preferences TEXT,
+  password_hash TEXT DEFAULT NULL,
+  password_changed_at DATETIME DEFAULT NULL,
+  previous_password_hashes TEXT DEFAULT NULL,
+  status TEXT DEFAULT 'active',
+  failed_login_attempts INTEGER DEFAULT 0,
+  last_failed_login DATETIME DEFAULT NULL,
+  locked_until DATETIME DEFAULT NULL,
+  mfa_enabled INTEGER DEFAULT 0,
+  mfa_enabled_at DATETIME DEFAULT NULL,
+  last_login DATETIME DEFAULT NULL,
+  last_login_ip TEXT DEFAULT NULL,
+  last_login_user_agent TEXT DEFAULT NULL,
+  created_by TEXT DEFAULT NULL,
+  updated_at DATETIME DEFAULT NULL,
+  updated_by TEXT DEFAULT NULL
+);
+
+-- Step 2: Copy data from old table (use email as id for existing users)
+INSERT INTO users_new (
+  id, email, role, name, created, phone, sms_optin, notification_preferences,
+  password_hash, password_changed_at, previous_password_hashes, status,
+  failed_login_attempts, last_failed_login, locked_until, mfa_enabled,
+  mfa_enabled_at, last_login, last_login_ip, last_login_user_agent,
+  created_by, updated_at, updated_by
+)
+SELECT
+  email as id, email, role, name, created, phone, sms_optin, notification_preferences,
+  password_hash, password_changed_at, previous_password_hashes, status,
+  failed_login_attempts, last_failed_login, locked_until, mfa_enabled,
+  mfa_enabled_at, last_login, last_login_ip, last_login_user_agent,
+  created_by, updated_at, updated_by
+FROM users;
+
+-- Step 3: Drop old table
+DROP TABLE users;
+
+-- Step 4: Rename new table
+ALTER TABLE users_new RENAME TO users;
+
+-- Step 5: Create indexes
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_status ON users(status);
+CREATE INDEX idx_users_role ON users(role);

--- a/src/pages/api/test-db.ts
+++ b/src/pages/api/test-db.ts
@@ -1,0 +1,59 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async ({ locals }) => {
+  try {
+    const db = locals.runtime?.env?.DB;
+    const kv = locals.runtime?.env?.CLRHOA_USERS;
+
+    if (!db || !kv) {
+      return new Response(
+        JSON.stringify({
+          error: 'Missing bindings',
+          hasDB: !!db,
+          hasKV: !!kv,
+        }),
+        {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Test DB query
+    const userCount = await db
+      .prepare('SELECT COUNT(*) as count FROM users')
+      .first<{ count: number }>();
+
+    // Test table existence
+    const tables = await db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('users', 'sessions', 'audit_logs')"
+      )
+      .all();
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        hasDB: true,
+        hasKV: true,
+        userCount: userCount?.count,
+        tables: tables.results,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+};


### PR DESCRIPTION
## Problem
Login was failing with 500 errors because Cloudflare Pages had NO bindings configured (DB and KV were both missing).

The root cause:  in GitHub Actions **completely ignores wrangler.toml** and doesn't configure bindings.

## Solution
Switch deployment method from  to  CLI command, which:
- ✅ Reads bindings from wrangler.toml
- ✅ Automatically configures D1, KV, and R2 bindings on the Pages project
- ✅ Applies the corrected `CLRHOA_USERS` binding name

## Additional Fixes
- **Users table migration**: Added `id` column as primary key for Lucia compatibility
- **Test endpoint**: Added `/api/test-db` to verify bindings are working

## Testing
After deployment, verify bindings are active:
```bash
curl https://clrhoa.com/api/test-db
# Should return: {"hasDB": true, "hasKV": true}
```

Then test login at https://clrhoa.com/auth/login