### PR TITLE
chore: Fresh Cloudflare deployment (new D1 + KV resources)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,12 +22,12 @@ pages_build_output_dir = "./dist"
 [[d1_databases]]
 binding = "DB"
 database_name = "clrhoa_db"
-database_id = "a214f9da-3577-4ee7-bc50-bc9b9754a79c"
+database_id = "66c2da44-c133-4e57-9352-e72637901cb4"
 
 # KV: email whitelist (key = lowercase email, value = "1" or JSON { "role": "admin" })
 [[kv_namespaces]]
 binding = "CLRHOA_USERS"
-id = "e936ea7760c04b268c4472eb24575d46"
+id = "45ba5f4e64864c1eb5fcc7a6705b0a70"
 
 # KV: SESSION storage for Lucia auth
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary

Complete fresh deployment with new Cloudflare resources to resolve authentication issues.

## Changes

### New Resources Created
- **D1 Database**: `66c2da44-c133-4e57-9352-e72637901cb4`
  - Fresh database with all schemas initialized
  - Core, RBAC, Features, and Auth tables created
- **CLRHOA_USERS KV**: `45ba5f4e64864c1eb5fcc7a6705b0a70`
  - Fresh namespace for user whitelist
  - `dagint@gmail.com` whitelisted as admin

### Kept Existing
- **SESSION KV**: `f2a5e8346928438baa1ca38e40ab200a` (will auto-clear)
- **KV namespace**: `9249262b4c7b483a9785097db451f8e6` (rate limiting)
- **R2 bucket**: `clrhoa-files` (existing files preserved)

## Deployment Process

1. ✅ Deleted old D1 database
2. ✅ Created fresh D1 database
3. ✅ Created fresh CLRHOA_USERS KV namespace
4. ✅ Initialized all database schemas
5. ✅ Whitelisted admin user
6. ✅ Updated wrangler.toml with new IDs
7. ⏳ **Pending**: GitHub Actions deployment

## Testing After Merge

1. Wait for deployment to complete (~5 min)
2. Visit site: https://clrhoa.com or https://clrhoa-site.pages.dev
3. Go to `/portal/login`
4. Login with `dagint@gmail.com`
5. Request password setup (should work with fresh auth system)
6. Complete setup and verify admin access

## Benefits

✅ Fresh D1 database - no legacy data issues
✅ Fresh KV whitelists - clean session state  
✅ Clean auth system - should resolve login issues
✅ All schemas properly initialized
✅ Admin user pre-configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)