### PR TITLE
fix: Implement lightweight Resend client for password reset emails

### DIFF
--- a/src/lib/resend-client.ts
+++ b/src/lib/resend-client.ts
@@ -1,0 +1,96 @@
+/**
+ * Lightweight Resend Email Client
+ *
+ * A minimal implementation of the ResendClient interface that uses fetch()
+ * instead of the full Resend SDK. This keeps bundle size small while providing
+ * the same interface expected by auth endpoints.
+ *
+ * Usage:
+ * ```typescript
+ * import { createResendClient } from './lib/resend-client';
+ *
+ * const resend = createResendClient(env.RESEND_API_KEY);
+ * await resend.emails.send({ from, to, subject, html, text });
+ * ```
+ */
+
+import type { ResendClient, ResendSendEmailParams, ResendSendEmailResponse } from '../types/resend';
+
+const RESEND_API_URL = 'https://api.resend.com/emails';
+
+/**
+ * Create a Resend client from an API key.
+ *
+ * @param apiKey - Resend API key (re_...)
+ * @returns ResendClient instance
+ */
+export function createResendClient(apiKey: string): ResendClient {
+  if (!apiKey || !apiKey.trim()) {
+    throw new Error('RESEND_API_KEY is required');
+  }
+
+  return {
+    emails: {
+      async send(params: ResendSendEmailParams): Promise<ResendSendEmailResponse> {
+        try {
+          const response = await fetch(RESEND_API_URL, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(params),
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            let errorMessage = `Resend API error (${response.status})`;
+
+            try {
+              const errorJson = JSON.parse(errorText);
+              errorMessage = errorJson.message || errorJson.error || errorText;
+            } catch {
+              errorMessage = errorText || errorMessage;
+            }
+
+            throw new Error(errorMessage);
+          }
+
+          const result = await response.json() as ResendSendEmailResponse;
+          return result;
+        } catch (error) {
+          if (error instanceof Error) {
+            throw error;
+          }
+          throw new Error(`Failed to send email: ${String(error)}`);
+        }
+      },
+    },
+  };
+}
+
+/**
+ * Get or create a Resend client from the environment.
+ *
+ * This function checks if env.RESEND is already a client instance,
+ * and if not, creates one from RESEND_API_KEY.
+ *
+ * @param env - Cloudflare environment with RESEND or RESEND_API_KEY
+ * @returns ResendClient instance or undefined if no API key
+ */
+export function getResendClient(env: {
+  RESEND?: unknown;
+  RESEND_API_KEY?: string;
+}): ResendClient | undefined {
+  // If RESEND is already a client, use it
+  if (env.RESEND && typeof env.RESEND === 'object' && 'emails' in env.RESEND) {
+    return env.RESEND as ResendClient;
+  }
+
+  // Otherwise, create client from API key
+  if (env.RESEND_API_KEY && env.RESEND_API_KEY.trim()) {
+    return createResendClient(env.RESEND_API_KEY);
+  }
+
+  return undefined;
+}

--- a/src/pages/api/admin/users/[email].ts
+++ b/src/pages/api/admin/users/[email].ts
@@ -37,7 +37,7 @@ import { requireRole } from '../../../../lib/auth/middleware';
 import { logAuditEvent } from '../../../../lib/audit-log';
 import { sendRoleChangeEmail } from '../../../../lib/auth/role-change-notifications';
 import { getUserEmail } from '../../../../types/auth';
-import type { ResendClient } from '../../../../types/resend';
+import { getResendClient } from '../../../../lib/resend-client';
 
 const VALID_ROLES = ['member', 'arb', 'board', 'arb_board', 'admin'];
 const VALID_STATUSES = ['active', 'pending_setup', 'inactive', 'locked'];
@@ -58,7 +58,7 @@ export const PATCH: APIRoute = async (context) => {
   }
 
   const db = context.locals.runtime?.env?.DB;
-  const resend = context.locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(context.locals.runtime.env);
 
   if (!db) {
     return new Response(

--- a/src/pages/api/admin/users/create.ts
+++ b/src/pages/api/admin/users/create.ts
@@ -35,7 +35,7 @@ import { requireRole } from '../../../../lib/auth/middleware';
 import { generateSetupToken, sendSetupEmail } from '../../../../lib/auth/setup-tokens';
 import { logAuditEvent } from '../../../../lib/audit-log';
 import { getUserEmail } from '../../../../types/auth';
-import type { ResendClient } from '../../../../types/resend';
+import { getResendClient } from '../../../../lib/resend-client';
 import { handleDatabaseError, getDatabaseErrorStatus, isDuplicateKeyError } from '../../../../lib/db-errors';
 import { validateAndNormalizeEmail } from '../../../../lib/email-validation';
 
@@ -60,7 +60,7 @@ export const POST: APIRoute = async (context) => {
   }
 
   const db = context.locals.runtime?.env?.DB;
-  const resend = context.locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(context.locals.runtime.env);
 
   if (!db) {
     return new Response(

--- a/src/pages/api/admin/users/resend-setup.ts
+++ b/src/pages/api/admin/users/resend-setup.ts
@@ -30,7 +30,7 @@ import { requireRole } from '../../../../lib/auth/middleware';
 import { resendSetupToken, sendSetupEmail } from '../../../../lib/auth/setup-tokens';
 import { logAuditEvent } from '../../../../lib/audit-log';
 import { getUserEmail } from '../../../../types/auth';
-import type { ResendClient } from '../../../../types/resend';
+import { getResendClient } from '../../../../lib/resend-client';
 
 interface ResendSetupRequest {
   email: string;
@@ -44,7 +44,7 @@ export const POST: APIRoute = async (context) => {
   }
 
   const db = context.locals.runtime?.env?.DB;
-  const resend = context.locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(context.locals.runtime.env);
 
   if (!db) {
     return new Response(

--- a/src/pages/api/admin/users/trigger-reset.ts
+++ b/src/pages/api/admin/users/trigger-reset.ts
@@ -31,7 +31,7 @@ import { requireRole } from '../../../../lib/auth/middleware';
 import { generateResetToken, sendResetEmail } from '../../../../lib/auth/reset-tokens';
 import { logAuditEvent } from '../../../../lib/audit-log';
 import { getUserEmail } from '../../../../types/auth';
-import type { ResendClient } from '../../../../types/resend';
+import { getResendClient } from '../../../../lib/resend-client';
 
 interface TriggerResetRequest {
   email: string;
@@ -45,7 +45,7 @@ export const POST: APIRoute = async (context) => {
   }
 
   const db = context.locals.runtime?.env?.DB;
-  const resend = context.locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(context.locals.runtime.env);
 
   if (!db) {
     return new Response(

--- a/src/pages/api/auth/change-password.ts
+++ b/src/pages/api/auth/change-password.ts
@@ -36,8 +36,8 @@ import { logSecurityEvent } from '../../../lib/audit-log';
 import { checkRateLimit } from '../../../lib/rate-limit';
 import { createLucia } from '../../../lib/lucia';
 import { getUserByEmail } from '../../../lib/db';
+import { getResendClient } from '../../../lib/resend-client';
 import type { AuthenticatedUser } from '../../../types/auth';
-import type { ResendClient } from '../../../types/resend';
 
 // Password validation constants
 const MIN_PASSWORD_LENGTH = 8;
@@ -81,7 +81,7 @@ export const prerender = false;
 export const POST: APIRoute = async ({ request, locals, cookies }) => {
   const db = locals.runtime?.env?.DB as D1Database | undefined;
   const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
-  const resend = locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(locals.runtime.env);
   const session = locals.session;
   const user = locals.user as AuthenticatedUser | null;
 

--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -31,6 +31,7 @@ import type { APIRoute } from 'astro';
 import { checkRateLimit } from '../../../lib/rate-limit';
 import { logSecurityEvent } from '../../../lib/audit-log';
 import { generateResetToken, sendResetEmail } from '../../../lib/auth/reset-tokens';
+import { getResendClient } from '../../../lib/resend-client';
 import crypto from 'node:crypto';
 import type { ResendClient } from '../../../types/resend';
 
@@ -48,7 +49,7 @@ export const prerender = false;
 export const POST: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB;
   const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
-  const resend = locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(locals.runtime.env);
   const ipAddress = request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = request.headers.get('user-agent') || 'unknown';
 

--- a/src/pages/api/auth/reset-password.ts
+++ b/src/pages/api/auth/reset-password.ts
@@ -38,7 +38,7 @@ import type { APIRoute } from 'astro';
 import { hashPassword } from '../../../lib/password';
 import { logSecurityEvent } from '../../../lib/audit-log';
 import { checkRateLimit } from '../../../lib/rate-limit';
-import type { ResendClient } from '../../../types/resend';
+import { getResendClient } from '../../../lib/resend-client';
 import { handleDatabaseError, getDatabaseErrorStatus } from '../../../lib/db-errors';
 import { createLucia } from '../../../lib/lucia';
 import crypto from 'node:crypto';
@@ -84,7 +84,7 @@ function validatePassword(password: string): { valid: boolean; error?: string } 
 export const POST: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB;
   const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
-  const resend = locals.runtime?.env?.RESEND as ResendClient | undefined;
+  const resend = getResendClient(locals.runtime.env);
   const ipAddress = request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = request.headers.get('user-agent') || 'unknown';
 


### PR DESCRIPTION
## Summary
- Fixes password reset and setup emails not sending
- Creates lightweight Resend client using fetch() API
- Updates all auth endpoints to use new client helper
- No new dependencies required

## Problem
Password reset emails weren't being sent because:
1. Auth endpoints expected `env.RESEND` to be a ResendClient SDK object
2. Only `RESEND_API_KEY` (string) was available in environment
3. Resend SDK was never installed
4. Code silently failed when `resend` was undefined

## Solution
Created `src/lib/resend-client.ts` that:
- Implements ResendClient interface using fetch() calls
- Matches the interface expected by auth endpoints
- Uses existing `RESEND_API_KEY` environment variable
- Keeps bundle size small (no SDK dependency)
- Provides `getResendClient()` helper for easy access

## Updated Files
- ✅ `src/lib/resend-client.ts` (new)
- ✅ `src/pages/api/auth/forgot-password.ts`
- ✅ `src/pages/api/auth/reset-password.ts`
- ✅ `src/pages/api/auth/change-password.ts`
- ✅ `src/pages/api/admin/users/[email].ts`
- ✅ `src/pages/api/admin/users/create.ts`
- ✅ `src/pages/api/admin/users/resend-setup.ts`
- ✅ `src/pages/api/admin/users/trigger-reset.ts`

## Testing
After merge and deployment:
1. Visit `/auth/forgot-password`
2. Enter `dagint@gmail.com`
3. Should receive password reset email from Resend
4. Email should contain reset link to `/auth/reset-password?token=...`

## Related
Part of fresh deployment troubleshooting. Also created initial admin user with setup token in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)