### PR TITLE
fix: Update backup worker resource IDs for fresh deployment

### DIFF
--- a/workers/backup/wrangler.toml
+++ b/workers/backup/wrangler.toml
@@ -15,11 +15,11 @@ crons = ["0 2 * * *"]
 [[d1_databases]]
 binding = "DB"
 database_name = "clrhoa_db"
-database_id = "a214f9da-3577-4ee7-bc50-bc9b9754a79c"
+database_id = "66c2da44-c133-4e57-9352-e72637901cb4"
 
 [[kv_namespaces]]
 binding = "CLOURHOA_USERS"
-id = "e936ea7760c04b268c4472eb24575d46"
+id = "45ba5f4e64864c1eb5fcc7a6705b0a70"
 
 [[r2_buckets]]
 binding = "BACKUP_R2"


### PR DESCRIPTION
## Problem
Deployment failing with error:
```  
binding DB of type d1 must have a database that already exists
```

Backup worker was still referencing old D1 and KV resource IDs from before the fresh deployment in PR #97.

## Solution
Updated  to use new resource IDs:
- **D1 database_id**: `a214f9da-3577-4ee7-bc50-bc9b9754a79c` → `66c2da44-c133-4e57-9352-e72637901cb4`
- **KV namespace id**: `e936ea7760c04b268c4472eb24575d46` → `45ba5f4e64864c1eb5fcc7a6705b0a70`

## Impact
- Fixes backup worker deployment
- Allows overall deployment to succeed
- After this merges, setup password link should work

Related to password reset setup for @dagint

🤖 Generated with [Claude Code](https://claude.com/claude-code)