### PR TITLE
fix: Enable SSR for setup-password page

### DIFF
--- a/src/pages/auth/setup-password.astro
+++ b/src/pages/auth/setup-password.astro
@@ -15,6 +15,7 @@
  * - Mobile-responsive design
  * - Automatic redirect to dashboard on success
  */
+export const prerender = false;
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 


### PR DESCRIPTION
## Problem
Setup password page was showing 'Invalid or missing setup link' even with valid token URL.

## Root Cause  
The page was missing `export const prerender = false`, causing it to be statically pre-rendered at build time. Pre-rendered pages can't access query parameters at runtime.

## Solution
Added `export const prerender = false` to enable server-side rendering.

## Testing
Debug page confirmed query parameters work when SSR is enabled:
- ✅ `/debug-token?token=xxx` → Shows token correctly
- ❌ `/auth/setup-password?token=xxx` → Was pre-rendered, couldn't read token
- ✅ `/auth/setup-password?token=xxx` → After this fix, will work

After merge, user can set up password with token:
```
https://clrhoa.com/auth/setup-password?token=410c4f3b233d656010edd086fa7f75d89ab33a9495d68669f27a793d31f67ce5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)