### PR TITLE
fix: Enable SSR for setup-password page to support query parameters

### DIFF
--- a/src/pages/auth/setup-password.astro
+++ b/src/pages/auth/setup-password.astro
@@ -15,6 +15,7 @@
  * - Mobile-responsive design
  * - Automatic redirect to dashboard on success
  */
+export const prerender = false;
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 


### PR DESCRIPTION
## Summary
- Fixes the setup-password page being unable to read the `token` query parameter
- The page was being statically pre-rendered, preventing access to URL query parameters at runtime
- Adding `export const prerender = false` enables server-side rendering

## Problem
Users clicking valid password setup links (`/auth/setup-password?token=xxx`) would see "Invalid or missing setup link" error because the token parameter wasn't accessible in the statically pre-rendered page.

## Solution
Enable SSR for the setup-password page by adding `export const prerender = false` to the frontmatter. This allows the page to read query parameters at request time.

## Changes
- Added SSR directive to `src/pages/auth/setup-password.astro` (1 line)

## Test plan
- [ ] Deploy to preview environment
- [ ] Create a test setup token via admin panel
- [ ] Click the setup link with token parameter
- [ ] Verify the password setup form appears (not the error state)
- [ ] Complete password setup successfully
- [ ] Verify redirect to dashboard works

🤖 Generated with [Claude Code](https://claude.com/claude-code)