### PR TITLE
fix: Add left margin to portal content to prevent sidebar overlap

### DIFF
--- a/src/components/PortalSidebar.astro
+++ b/src/components/PortalSidebar.astro
@@ -280,6 +280,7 @@ const icons: Record<string, string> = {
     const overlay = document.getElementById('sidebar-overlay');
     const collapseBtn = document.getElementById('sidebar-collapse-btn');
     const header = document.querySelector('.portal-header');
+    const content = document.getElementById('portal-content');
     const STORAGE_KEY = 'clrhoa_sidebar_collapsed';
 
     if (!sidebar || !overlay) return;
@@ -308,6 +309,11 @@ const icons: Record<string, string> = {
           header.classList.add('lg:left-20');
         }
 
+        if (content) {
+          content.classList.remove('lg:ml-72');
+          content.classList.add('lg:ml-20');
+        }
+
         collapseBtn?.setAttribute('title', 'Expand sidebar');
       } else {
         // Expand to full width
@@ -322,6 +328,11 @@ const icons: Record<string, string> = {
         if (header) {
           header.classList.remove('lg:left-20');
           header.classList.add('lg:left-72');
+        }
+
+        if (content) {
+          content.classList.remove('lg:ml-20');
+          content.classList.add('lg:ml-72');
         }
 
         collapseBtn?.setAttribute('title', 'Collapse sidebar');

--- a/src/pages/portal/dashboard.astro
+++ b/src/pages/portal/dashboard.astro
@@ -115,7 +115,7 @@ const showActionNeededBanner = showActionFeedback || showActionMaintenance || sh
     />
 
     <!-- Main Content Area -->
-    <div class="flex-1 flex flex-col overflow-hidden">
+    <div id="portal-content" class="flex-1 flex flex-col overflow-hidden lg:ml-72 transition-all duration-300">
       <!-- Top Header -->
       <PortalHeader userName={displayName ?? undefined} userEmail={email} effectiveRole={effectiveRole}>
         <span slot="title">Dashboard</span>

--- a/src/pages/portal/profile/security.astro
+++ b/src/pages/portal/profile/security.astro
@@ -72,7 +72,7 @@ function formatDate(iso: string | null | undefined): string {
     />
 
     <!-- Main Content Area -->
-    <div class="flex-1 flex flex-col overflow-hidden">
+    <div id="portal-content" class="flex-1 flex flex-col overflow-hidden lg:ml-72 transition-all duration-300">
       <!-- Top Header -->
       <PortalHeader userName={displayName ?? undefined} userEmail={email} effectiveRole={effectiveRole}>
         <span slot="title">Security Settings</span>


### PR DESCRIPTION
## Problem
The fixed-position green sidebar was overlapping/covering the main content area on all portal pages. Content was being cut off on the left side.

## Solution
Added left margin (`lg:ml-72`) to the main content wrapper that accounts for the sidebar width:
- **Expanded sidebar**: 288px margin (w-72)
- **Collapsed sidebar**: 80px margin (w-20)
- **Mobile**: No margin (sidebar slides over content)

## Changes
- Updated dashboard.astro main content div
- Updated security.astro main content div
- Enhanced PortalSidebar.astro JavaScript to toggle content margin when sidebar collapses/expands
- Smooth transition on sidebar state changes

## Fixes
✅ Dashboard content no longer hidden behind sidebar
✅ Security page content properly offset
✅ Content margin automatically adjusts when sidebar is collapsed
✅ Mobile layout unaffected

## Screenshots
Before: Content was being cut off under the green sidebar
After: Content properly offset with full visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)