### PR TITLE
fix: Use correct KV namespace for rate limiting (fixes #109)

### DIFF
--- a/src/pages/api/auth/change-password.ts
+++ b/src/pages/api/auth/change-password.ts
@@ -80,7 +80,7 @@ export const prerender = false;
 
 export const POST: APIRoute = async ({ request, locals, cookies }) => {
   const db = locals.runtime?.env?.DB as D1Database | undefined;
-  const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = locals.runtime?.env?.KV as KVNamespace | undefined;
   const resend = getResendClient(locals.runtime.env);
   const session = locals.session;
   const user = locals.user as AuthenticatedUser | null;

--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -48,7 +48,7 @@ export const prerender = false;
 
 export const POST: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB;
-  const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = locals.runtime?.env?.KV as KVNamespace | undefined;
   const resend = getResendClient(locals.runtime.env);
   const ipAddress = request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = request.headers.get('user-agent') || 'unknown';

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -87,7 +87,7 @@ function getClientIP(request: Request): string {
  */
 export const POST: APIRoute = async ({ request, locals, cookies }) => {
   const db = locals.runtime?.env?.DB as D1Database | undefined;
-  const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = locals.runtime?.env?.KV as KVNamespace | undefined;
 
   if (!db || !kv) {
     return new Response(

--- a/src/pages/api/auth/mfa/disable.ts
+++ b/src/pages/api/auth/mfa/disable.ts
@@ -62,7 +62,7 @@ export const POST: APIRoute = async (context) => {
   const userEmail = getUserEmail(user) || 'unknown';
 
   const db = context.locals.runtime?.env?.DB;
-  const kv = context.locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = context.locals.runtime?.env?.KV as KVNamespace | undefined;
   const sessionSecret = context.locals.runtime?.env?.SESSION_SECRET;
   const ipAddress = context.request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = context.request.headers.get('user-agent') || 'unknown';

--- a/src/pages/api/auth/mfa/enable.ts
+++ b/src/pages/api/auth/mfa/enable.ts
@@ -64,7 +64,7 @@ export const POST: APIRoute = async (context) => {
   const userEmail = getUserEmail(user) || 'unknown';
 
   const db = context.locals.runtime?.env?.DB;
-  const kv = context.locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = context.locals.runtime?.env?.KV as KVNamespace | undefined;
   const sessionSecret = context.locals.runtime?.env?.SESSION_SECRET;
   const ipAddress = context.request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = context.request.headers.get('user-agent') || 'unknown';

--- a/src/pages/api/auth/mfa/setup.ts
+++ b/src/pages/api/auth/mfa/setup.ts
@@ -50,7 +50,7 @@ export const POST: APIRoute = async (context) => {
   const userEmail = getUserEmail(user) || 'unknown';
 
   const db = context.locals.runtime?.env?.DB;
-  const kv = context.locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = context.locals.runtime?.env?.KV as KVNamespace | undefined;
   const sessionSecret = context.locals.runtime?.env?.SESSION_SECRET;
   const ipAddress = context.request.headers.get('cf-connecting-ip') || 'unknown';
 

--- a/src/pages/api/auth/mfa/verify-login.ts
+++ b/src/pages/api/auth/mfa/verify-login.ts
@@ -52,7 +52,7 @@ interface VerifyMFALoginRequest {
 
 export const POST: APIRoute = async (context) => {
   const db = context.locals.runtime?.env?.DB;
-  const kv = context.locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = context.locals.runtime?.env?.KV as KVNamespace | undefined;
   const sessionSecret = context.locals.runtime?.env?.SESSION_SECRET;
   const ipAddress = context.request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = context.request.headers.get('user-agent') || 'unknown';

--- a/src/pages/api/auth/reset-password.ts
+++ b/src/pages/api/auth/reset-password.ts
@@ -84,7 +84,7 @@ function validatePassword(password: string): { valid: boolean; error?: string } 
 
 export const POST: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB;
-  const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+  const kv = locals.runtime?.env?.KV as KVNamespace | undefined;
   const resend = getResendClient(locals.runtime.env);
   const ipAddress = request.headers.get('cf-connecting-ip') || 'unknown';
   const userAgent = request.headers.get('user-agent') || 'unknown';

--- a/src/pages/api/auth/setup-password.ts
+++ b/src/pages/api/auth/setup-password.ts
@@ -130,7 +130,7 @@ export const POST: APIRoute = async ({ request, locals, cookies }) => {
     }
 
     // 2. Rate limiting - prevent token brute force (10 attempts per hour per IP)
-    const kv = locals.runtime?.env?.CLRHOA_USERS as KVNamespace | undefined;
+    const kv = locals.runtime?.env?.KV as KVNamespace | undefined;
     const rateLimitResult = await checkRateLimit(
       kv,
       '/api/auth/setup-password',


### PR DESCRIPTION
## Summary

Fixes #109 - RATE_LIMITS KV namespace not populated

### Problem
All auth endpoints were using the wrong KV namespace () for rate limiting instead of the dedicated rate limiting namespace (). This caused rate limiting to fail because:
-  is meant for email whitelist storage
-  is the dedicated namespace for rate limiting and login lockout (per wrangler.toml line 37-40)

### Root Cause
Copy-paste error - when creating auth endpoints, the wrong KV binding was used consistently across all files.

### Solution
Changed all 9 auth endpoint files to use `locals.runtime?.env?.KV` instead of `locals.runtime?.env?.CLRHOA_USERS` for rate limiting.

### Files Fixed
✅ auth/login.ts  
✅ auth/change-password.ts  
✅ auth/forgot-password.ts  
✅ auth/reset-password.ts  
✅ auth/setup-password.ts  
✅ auth/mfa/disable.ts  
✅ auth/mfa/enable.ts  
✅ auth/mfa/setup.ts  
✅ auth/mfa/verify-login.ts  

### Impact
**Before:** Rate limiting was not working - malicious users could brute force passwords  
**After:** Rate limiting now works correctly:
- Login: 5 attempts per 15 minutes
- Password reset: 3 attempts per hour
- MFA verification: 10 attempts per 15 minutes
- Other endpoints: see src/lib/rate-limit.ts for full config

### Testing
Rate limiting will now properly prevent:
- Brute force password attacks
- Email enumeration
- Abuse of password reset
- MFA code brute forcing

Closes #109