### PR TITLE
feat: Add contact sharing status badge to profile page

### DIFF
--- a/src/pages/portal/profile.astro
+++ b/src/pages/portal/profile.astro
@@ -101,6 +101,33 @@ const householdMembersWithLogin = db ? await listHouseholdMembersWithLogin(db, e
               <p class="text-sm text-gray-500 mt-1">Login address; cannot be changed here.</p>
             </div>
           </dl>
+
+          <!-- Contact Sharing Status -->
+          <div class="mt-6 pt-6 border-t border-gray-200">
+            {owner?.share_contact_with_members !== 0 ? (
+              <div class="flex items-start gap-3 p-4 bg-green-50 border border-green-200 rounded-lg">
+                <svg class="w-5 h-5 text-green-600 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
+                </svg>
+                <div class="flex-1">
+                  <p class="text-base font-semibold text-green-900">Contact info shared in directory</p>
+                  <p class="text-sm text-green-800 mt-1">Other HOA members can see your phone number and email in the member directory.</p>
+                  <a href="/portal/preferences" class="text-sm text-green-700 hover:text-green-900 underline font-medium mt-2 inline-block">Change privacy settings</a>
+                </div>
+              </div>
+            ) : (
+              <div class="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg">
+                <svg class="w-5 h-5 text-amber-600 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clip-rule="evenodd" />
+                </svg>
+                <div class="flex-1">
+                  <p class="text-base font-semibold text-amber-900">Contact info is private</p>
+                  <p class="text-sm text-amber-800 mt-1">Your contact info is hidden from other members. Board/ARB/Admin can still see it when needed.</p>
+                  <a href="/portal/preferences" class="text-sm text-amber-700 hover:text-amber-900 underline font-medium mt-2 inline-block">Enable sharing in preferences</a>
+                </div>
+              </div>
+            )}
+          </div>
           <div class="mt-8">
             <button type="button" id="profile-edit-btn" class="px-6 py-3 bg-clr-green text-white rounded-lg font-semibold text-base hover:brightness-110 transition-all">Edit directory info</button>
           </div>


### PR DESCRIPTION
## Summary
Adds a prominent visual indicator to the profile page showing whether contact information is shared in the member directory or kept private. This addresses the main UX gap identified in Issue #134 (Option A).

## Changes

### Visual Status Badge
Added a contact sharing status section to `/portal/profile` that displays:

**When contact info is shared (green badge):**
- ✓ Checkmark icon
- "Contact info shared in directory"
- Explanation: "Other HOA members can see your phone number and email in the member directory"
- Link: "Change privacy settings" → `/portal/preferences`

**When contact info is private (amber badge):**
- 🔒 Lock icon
- "Contact info is private"
- Explanation: "Your contact info is hidden from other members. Board/ARB/Admin can still see it when needed."
- Link: "Enable sharing in preferences" → `/portal/preferences`

### Location
- Placed in the "Directory listing" view section
- Appears after the email field, before the "Edit directory info" button
- Separated with a border-top divider for visual clarity

### Design
- Uses existing green/amber color scheme from the portal
- Responsive flex layout with icons
- Clear typography hierarchy (bold title, regular explanation, underlined link)
- Consistent with other alert/info boxes in the portal

## User Benefits

1. **Immediate visibility** - Users can see their privacy status without navigating to preferences
2. **Clear explanation** - No ambiguity about what "shared" means
3. **Easy access** - One click to change settings
4. **Transparency** - Notes that staff can still see contact info when needed
5. **Better UX** - Addresses confusion about whether contact info is visible to others

## Technical Details

- Uses existing `share_contact_with_members` column from `owners` table
- No database changes required
- No API changes required
- TypeScript/Astro check passes with no errors
- Follows existing code patterns and design system

## Testing Checklist

- [ ] View profile with `share_contact_with_members = 1` → Shows green "shared" badge
- [ ] View profile with `share_contact_with_members = 0` → Shows amber "private" badge
- [ ] Click "Change privacy settings" → Navigates to `/portal/preferences`
- [ ] Click "Enable sharing in preferences" → Navigates to `/portal/preferences`
- [ ] Mobile responsive - Badge layout works on small screens
- [ ] Verify badge appears in view mode (not edit mode)

## Screenshots

### Shared Status (Green Badge)
```
┌─────────────────────────────────────────────────┐
│ ✓ Contact info shared in directory             │
│ Other HOA members can see your phone number    │
│ and email in the member directory.             │
│ → Change privacy settings                      │
└─────────────────────────────────────────────────┘
```

### Private Status (Amber Badge)
```
┌─────────────────────────────────────────────────┐
│ 🔒 Contact info is private                     │
│ Your contact info is hidden from other members.│
│ Board/ARB/Admin can still see it when needed.  │
│ → Enable sharing in preferences                │
└─────────────────────────────────────────────────┘
```

## Related

- Partially addresses #134 (Option A: Contact sharing status indicator)
- Complements existing privacy toggle in `/portal/preferences`
- Future work: Option B could enhance household members section to show all directory entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)