### PR TITLE
chore: Add migration for pim_elevation_log table

### DIFF
--- a/scripts/apply-pim-migration.sh
+++ b/scripts/apply-pim-migration.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Apply PIM elevation log table migration
+# Usage: ./scripts/apply-pim-migration.sh [local|remote]
+
+set -e
+
+ENVIRONMENT=${1:-remote}
+MIGRATION_FILE="scripts/migrations/add-pim-elevation-log-table.sql"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  PIM Elevation Log Table Migration"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Environment: $ENVIRONMENT"
+echo "Migration:   $MIGRATION_FILE"
+echo ""
+
+if [ "$ENVIRONMENT" != "local" ] && [ "$ENVIRONMENT" != "remote" ]; then
+    echo "❌ Error: Environment must be 'local' or 'remote'"
+    echo "Usage: $0 [local|remote]"
+    exit 1
+fi
+
+if [ ! -f "$MIGRATION_FILE" ]; then
+    echo "❌ Error: Migration file not found: $MIGRATION_FILE"
+    exit 1
+fi
+
+echo "📋 Migration preview:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+head -20 "$MIGRATION_FILE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+if [ "$ENVIRONMENT" = "remote" ]; then
+    echo "⚠️  WARNING: This will apply the migration to PRODUCTION!"
+    echo ""
+    read -p "Are you sure you want to continue? (yes/no): " confirmation
+    if [ "$confirmation" != "yes" ]; then
+        echo "❌ Migration cancelled"
+        exit 0
+    fi
+    echo ""
+fi
+
+echo "🔄 Applying migration..."
+wrangler d1 execute clrhoa_db --$ENVIRONMENT --file="$MIGRATION_FILE"
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Migration applied successfully!"
+    echo ""
+    echo "🔍 Verifying table exists..."
+    wrangler d1 execute clrhoa_db --$ENVIRONMENT --command="SELECT sql FROM sqlite_master WHERE type='table' AND name='pim_elevation_log';"
+    echo ""
+    echo "✅ Done! The pim_elevation_log table is now available."
+else
+    echo ""
+    echo "❌ Migration failed. Check the error above."
+    exit 1
+fi

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,0 +1,73 @@
+# Database Migrations
+
+This directory contains SQL migration files for the D1 database.
+
+## Running Migrations
+
+### Production (Remote D1)
+
+```bash
+# Run a specific migration on production
+wrangler d1 execute clrhoa_db --remote --file=scripts/migrations/<migration-file>.sql
+
+# Example: Apply PIM elevation log table
+wrangler d1 execute clrhoa_db --remote --file=scripts/migrations/add-pim-elevation-log-table.sql
+```
+
+### Local Development
+
+```bash
+# Run a specific migration locally
+wrangler d1 execute clrhoa_db --local --file=scripts/migrations/<migration-file>.sql
+
+# Example: Apply PIM elevation log table locally
+wrangler d1 execute clrhoa_db --local --file=scripts/migrations/add-pim-elevation-log-table.sql
+```
+
+## Verifying Migrations
+
+After running a migration, verify it was applied:
+
+```bash
+# Remote
+wrangler d1 execute clrhoa_db --remote --command="SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+
+# Local
+wrangler d1 execute clrhoa_db --local --command="SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+```
+
+## Migration Files
+
+| File | Description | Date | Status |
+|------|-------------|------|--------|
+| `add-users-id-column.sql` | Add id column to users table | 2026-02-14 | Applied |
+| `add-owners-phones-column.sql` | Add phones column to owners table | 2026-02-14 | Applied |
+| `fix-sessions-expires-at.sql` | Fix sessions expires_at column type | 2026-02-14 | Applied |
+| `add-pim-elevation-log-table.sql` | Add PIM elevation audit log table | 2026-02-15 | **Pending** |
+
+## Best Practices
+
+1. **Always test locally first** before running on production
+2. **Use `CREATE TABLE IF NOT EXISTS`** to make migrations idempotent
+3. **Include rollback instructions** in migration comments when applicable
+4. **Document the migration** in this README after applying
+5. **Backup production data** before running destructive migrations
+
+## Troubleshooting
+
+### "Table already exists" error
+If you get this error, the migration was likely already applied. Verify with:
+```bash
+wrangler d1 execute clrhoa_db --remote --command="SELECT sql FROM sqlite_master WHERE type='table' AND name='<table_name>';"
+```
+
+### "No such database" error
+Make sure you've created the D1 database:
+```bash
+wrangler d1 list
+```
+
+If it doesn't exist, create it:
+```bash
+wrangler d1 create clrhoa_db
+```

--- a/scripts/migrations/add-pim-elevation-log-table.sql
+++ b/scripts/migrations/add-pim-elevation-log-table.sql
@@ -1,0 +1,29 @@
+-- Migration: Add pim_elevation_log table for PIM/JIT elevation audit
+-- Date: 2026-02-15
+-- Description: Creates the pim_elevation_log table to track who elevated when and when it expires.
+--              This table is used by the PIM (Privileged Identity Management) system to audit
+--              elevation requests and drops for admin/board/ARB users.
+--
+-- Required for: Issue #110 - PIM elevation flow
+-- Run on: Production D1 database (clrhoa_db)
+--
+-- Usage:
+--   Local:  wrangler d1 execute clrhoa_db --local --file=scripts/migrations/add-pim-elevation-log-table.sql
+--   Remote: wrangler d1 execute clrhoa_db --remote --file=scripts/migrations/add-pim-elevation-log-table.sql
+
+-- Create pim_elevation_log table
+CREATE TABLE IF NOT EXISTS pim_elevation_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL,
+  action TEXT NOT NULL,                          -- 'elevate' or 'drop'
+  elevated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT                                -- ISO timestamp for when elevation expires (NULL for 'drop' action)
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_pim_elevation_email ON pim_elevation_log(email);
+CREATE INDEX IF NOT EXISTS idx_pim_elevation_at ON pim_elevation_log(elevated_at);
+
+-- Verify table was created
+-- SELECT sql FROM sqlite_master WHERE type='table' AND name='pim_elevation_log';


### PR DESCRIPTION
## Problem

Production database is missing the `pim_elevation_log` table, causing PIM elevation requests to fail with:

```
Error: D1_ERROR: no such table: pim_elevation_log: SQLITE_ERROR
```

## Solution

Created an idempotent migration to add the `pim_elevation_log` table to production.

### Files Added

1. **`scripts/migrations/add-pim-elevation-log-table.sql`**
   - Creates `pim_elevation_log` table with columns: id, email, role, action, elevated_at, expires_at
   - Adds indexes on email and elevated_at for efficient querying
   - Idempotent (uses `CREATE TABLE IF NOT EXISTS`)

2. **`scripts/apply-pim-migration.sh`**
   - Helper script to apply the migration
   - Supports both local and remote environments
   - Includes confirmation prompt for production
   - Verifies table creation after applying

3. **`scripts/migrations/README.md`**
   - Documents migration process
   - Lists all migrations and their status
   - Provides troubleshooting guidance

## Migration Schema

```sql
CREATE TABLE IF NOT EXISTS pim_elevation_log (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  email TEXT NOT NULL,
  role TEXT NOT NULL,
  action TEXT NOT NULL,                          -- 'elevate' or 'drop'
  elevated_at TEXT NOT NULL DEFAULT (datetime('now')),
  expires_at TEXT                                -- ISO timestamp (NULL for 'drop')
);

CREATE INDEX IF NOT EXISTS idx_pim_elevation_email ON pim_elevation_log(email);
CREATE INDEX IF NOT EXISTS idx_pim_elevation_at ON pim_elevation_log(elevated_at);
```

## Usage

### Quick Apply (Recommended)

```bash
# Apply to production (with confirmation prompt)
./scripts/apply-pim-migration.sh remote

# Apply to local dev
./scripts/apply-pim-migration.sh local
```

### Manual Apply

```bash
# Production
wrangler d1 execute clrhoa_db --remote --file=scripts/migrations/add-pim-elevation-log-table.sql

# Local
wrangler d1 execute clrhoa_db --local --file=scripts/migrations/add-pim-elevation-log-table.sql
```

### Verify

```bash
# Check table exists
wrangler d1 execute clrhoa_db --remote --command="SELECT sql FROM sqlite_master WHERE type='table' AND name='pim_elevation_log';"
```

## After Merging

**Action Required**: Run the migration on production to fix the PIM elevation flow.

```bash
./scripts/apply-pim-migration.sh remote
```

This will enable:
- ✅ Admin users can request elevated access
- ✅ Elevation requests are audited in the database
- ✅ Drop elevation events are logged
- ✅ PIM audit log page can display elevation history

## Related

- Fixes production 500 error in `/api/pim/elevate`
- Part of Issue #110 - PIM implementation
- Required for elevation flow to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)