### PR TITLE
fix: Include elevated_until in Lucia session validation

### DIFF
--- a/src/lib/auth/middleware.ts
+++ b/src/lib/auth/middleware.ts
@@ -64,6 +64,14 @@ export async function validateSession(
 
     if (!result.session || !result.user) {
       console.log('[VALIDATE DEBUG] Session validation returned null/invalid');
+      return result;
+    }
+
+    // Manually fetch custom session attributes (Lucia D1 adapter doesn't include them)
+    // This includes elevated_until for PIM (Privileged Identity Management)
+    if (result.session && dbSession) {
+      (result.session as any).elevated_until = dbSession.elevated_until;
+      console.log('[VALIDATE DEBUG] Added elevated_until to session:', dbSession.elevated_until);
     }
 
     return result;


### PR DESCRIPTION
## Problem

PIM elevation flow shows success but redirects back to the elevation page in a loop:

1. User enters password on `/portal/request-elevated-access`
2. API successfully grants elevation (updates `elevated_until` in DB)
3. Shows "Elevated access granted! Redirecting..."
4. Redirects to `/portal/admin`
5. **Middleware doesn't see elevation** → Redirects back to elevation page
6. **Loop continues**

**Root cause:** Lucia's D1 adapter only fetches standard session columns (`id`, `user_id`, `expires_at`). Custom columns like `elevated_until` are not included in the Session object returned by `validateSession()`.

## Solution

Manually add `elevated_until` from the database query to the Lucia session object after validation.

### Changes

**`src/lib/auth/middleware.ts`** - `validateSession()` function:

```typescript
// After Lucia validation succeeds...
if (result.session && dbSession) {
  // Manually fetch custom session attributes (Lucia D1 adapter doesn't include them)
  // This includes elevated_until for PIM (Privileged Identity Management)
  (result.session as any).elevated_until = dbSession.elevated_until;
  console.log('[VALIDATE DEBUG] Added elevated_until to session:', dbSession.elevated_until);
}
```

### Why this works

1. `validateSession` already queries the database for session data (`dbSession`)
2. This query includes ALL columns, including `elevated_until`
3. Lucia's validation returns a Session object with only standard fields
4. We copy `elevated_until` from our DB query to the Lucia session
5. Now middleware can check `(session as any).elevated_until` and it exists!

### No Performance Impact

- Uses existing DB query (no additional query)
- Only copies one field from memory to memory
- Backwards compatible (only adds field if session valid)

## Testing

**Before:**
- ❌ Request elevation → Success → Redirect loop
- ❌ Middleware: `elevated_until` always `undefined`
- ❌ Never reaches admin portal

**After (expected):**
- ✅ Request elevation → Success → Redirects to `/portal/admin`  
- ✅ Middleware: `elevated_until` contains Unix timestamp
- ✅ Elevation banner shows countdown
- ✅ Can access elevated features for 60 minutes
- ✅ Drop elevation works correctly

## Related

- Fixes Issue #110 production elevation redirect loop
- Complements PR #139 (middleware /api/pim handler)
- Complements PR #140 (migration for pim_elevation_log table)

## Alternative Considered

Could extend D1Adapter to support custom session attributes, but:
- More complex implementation
- Requires forking/extending Lucia adapter
- This solution is simpler and works with standard Lucia

🤖 Generated with [Claude Code](https://claude.com/claude-code)