### PR TITLE
Fix broken template in directory page

### DIFF
--- a/src/pages/board/directory.astro
+++ b/src/pages/board/directory.astro
@@ -8,7 +8,7 @@ import { listOwners } from '../../lib/directory-db';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 
-import AdminNav from '../../components/BoardNav.astro';
+import AdminNav from '../../components/AdminNav.astro';
 const ctx = await getAdminContext(Astro);
 if ('redirect' in ctx) return Astro.redirect(ctx.redirect);
 const { env, session, effectiveRole } = ctx;
@@ -69,11 +69,15 @@ function roleLabel(role: string): string {
     vendorPendingCount={badges.vendorPendingCount}
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
+    feedbackDueCount={badges.feedbackDueCount}
   >
     <AdminNav currentPath="/board/directory" />
 
-unt}
-<div id="directory-message" class="hidden mb-4 p-4 rounded-xl border" role="status" aria-live="polite" aria-atomic="true"></div>
+    <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
+      <h1 class="text-3xl font-heading font-bold text-clr-green mb-2">Directory</h1>
+      <p class="text-base text-gray-600 mb-6">Homeowner contact information and roles.</p>
+
+      <div id="directory-message" class="hidden mb-4 p-4 rounded-xl border" role="status" aria-live="polite" aria-atomic="true"></div>
   {canEditDirectory && (
   <>
   <h2 class="text-3xl font-heading font-bold text-clr-green mb-6">Add or edit owner</h2>


### PR DESCRIPTION
Fixes corrupted template from batch edit that showed 'unt}' and missing page header.