### PR TITLE
Fix backup page 401 errors - migrate to Lucia auth

### DIFF
--- a/src/pages/api/board/backup-config.astro
+++ b/src/pages/api/board/backup-config.astro
@@ -5,20 +5,21 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole, isElevatedRole } from '../../../lib/auth';
+import { getUserEmail, getUserRole } from '../../../types/auth';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
 
-if (!session) {
+// Use session from middleware (already validated by middleware for /api/board/* routes)
+const user = Astro.locals.user;
+const luciaSession = Astro.locals.session;
+
+if (!user || !luciaSession) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
-const effectiveRole = getEffectiveRole(session);
-const canManageBackup = effectiveRole === 'board' || effectiveRole === 'admin' || effectiveRole === 'arb_board';
+
+const userRole = getUserRole(user)?.toLowerCase() || 'member';
+const canManageBackup = userRole === 'board' || userRole === 'admin' || userRole === 'arb_board';
 if (!canManageBackup) {
   return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
 }
@@ -100,7 +101,7 @@ if (Astro.request.method === 'POST') {
     schedule_day_of_week ?? null,
     include_r2_manifest ? 1 : 0,
     include_r2_files ? 1 : 0,
-    session.email
+    getUserEmail(user)
   ).run();
 
   return new Response(JSON.stringify({ ok: true }), {

--- a/src/pages/api/board/backup-download.astro
+++ b/src/pages/api/board/backup-download.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../../lib/auth';
+import { getUserRole } from '../../../types/auth';
 import { buildZip } from '../../../lib/zip-simple';
 
 const runtime = Astro.locals.runtime;
@@ -15,19 +15,18 @@ const env = runtime?.env as Env & {
   D1_DATABASE_ID?: string;
 };
 
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+// Use session from middleware (already validated by middleware for /api/board/* routes)
+const user = Astro.locals.user;
+const luciaSession = Astro.locals.session;
 
-if (!session) {
+if (!user || !luciaSession) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
   });
 }
 
-const effectiveRole = getEffectiveRole(session);
+const effectiveRole = getUserRole(user)?.toLowerCase() || 'member';
 const canDownloadBackup = effectiveRole === 'board' || effectiveRole === 'admin' || effectiveRole === 'arb_board';
 if (!canDownloadBackup) {
   return new Response(JSON.stringify({ error: 'Forbidden' }), {

--- a/src/pages/api/board/backup-status.astro
+++ b/src/pages/api/board/backup-status.astro
@@ -5,20 +5,21 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../../lib/auth';
+import { getUserRole } from '../../../types/auth';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env as Record<string, unknown> & { CLOUDFLARE_ACCOUNT_ID?: string; CLOUDFLARE_BACKUP_API_TOKEN?: string };
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET as string | undefined
-);
 
-if (!session) {
+// Use session from middleware (already validated by middleware for /api/board/* routes)
+const user = Astro.locals.user;
+const luciaSession = Astro.locals.session;
+
+if (!user || !luciaSession) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
-const effectiveRole = getEffectiveRole(session);
-const canManageBackup = effectiveRole === 'board' || effectiveRole === 'admin' || effectiveRole === 'arb_board';
+
+const userRole = getUserRole(user)?.toLowerCase() || 'member';
+const canManageBackup = userRole === 'board' || userRole === 'admin' || userRole === 'arb_board';
 if (!canManageBackup) {
   return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
 }


### PR DESCRIPTION
Fixes #151

## Problem
Backup page was showing 401 Unauthorized errors on all API calls because the backup endpoints used legacy `getSessionFromCookie()` auth, which can't read Lucia session cookies.

## Solution
Migrated 3 backup API endpoints to use Lucia sessions from middleware:
- ✅ `/api/board/backup-config` (GET + POST)
- ✅ `/api/board/backup-status` (GET)
- ✅ `/api/board/backup-download` (GET)

## Changes
- Replaced `getSessionFromCookie()` with `Astro.locals.user` + `Astro.locals.session`
- Use `getUserRole()` and `getUserEmail()` helpers for Lucia user objects
- Auth is already validated by middleware for `/api/board/*` routes

## Testing
- ✅ Backup page loads without 401 errors
- ✅ GET /api/board/backup-config returns backup settings
- ✅ POST /api/board/backup-config saves settings
- ✅ GET /api/board/backup-status returns status

## Related
Part of larger auth migration - this fixes 3 of the 21 API endpoints still using legacy auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)