### PR TITLE
debug: Add error logging for D1 export API

### DIFF
--- a/src/pages/api/board/backup-download.astro
+++ b/src/pages/api/board/backup-download.astro
@@ -75,6 +75,14 @@ let res = await fetch(base, {
 });
 if (!res.ok) {
   const t = await res.text();
+  console.error('[BACKUP DOWNLOAD ERROR]', {
+    status: res.status,
+    statusText: res.statusText,
+    responseBody: t,
+    apiUrl: base,
+    accountIdLength: accountId?.length,
+    tokenLength: apiToken?.length,
+  });
   return new Response(JSON.stringify({ error: `D1 export failed: ${t}` }), {
     status: 502,
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Add detailed error logging to capture what Cloudflare's D1 export API returns when it fails, including status, response body, and API URL.