### PR TITLE
fix: Add output_format to D1 export polling requests

### DIFF
--- a/src/pages/api/board/backup-download.astro
+++ b/src/pages/api/board/backup-download.astro
@@ -102,7 +102,7 @@ let bookmark = start.result.at_bookmark;
 // Poll until complete (reduced iterations to fit within Pages Function timeout)
 for (let i = 0; i < 8; i++) {
   await new Promise((r) => setTimeout(r, 1500));
-  res = await fetch(base, { method: 'POST', headers, body: JSON.stringify({ current_bookmark: bookmark }) });
+  res = await fetch(base, { method: 'POST', headers, body: JSON.stringify({ output_format: 'polling', current_bookmark: bookmark }) });
   if (!res.ok) {
     const errorText = await res.text();
     console.error('[BACKUP POLL] Fetch failed', { iteration: i, status: res.status, error: errorText, bookmark });


### PR DESCRIPTION
## Problem
Backup download was failing with 400 Bad Request on the first polling iteration.

Error: "Invalid property: output_format => Required"

## Root Cause
The D1 export API requires `output_format: 'polling'` in **every** polling request, not just the initial export request.

## Solution
✅ Add `output_format: 'polling'` to the polling request body

**Before:**
```javascript
{ current_bookmark: bookmark }  // ❌ Missing output_format
```

**After:**
```javascript  
{ output_format: 'polling', current_bookmark: bookmark }  // ✅
```

## Testing
This should finally make the backup download work! The polling requests will now succeed and the D1 export can complete.

Fixes #151