### PR TITLE
fix: Update backup Worker D1_DATABASE_ID to production database

### DIFF
--- a/workers/backup/wrangler.toml
+++ b/workers/backup/wrangler.toml
@@ -30,7 +30,7 @@ bucket_name = "clrhoa-files"
 # If you use CI/CD, ensure this value is your real account ID (e.g. edd8cf1c48ad414729e72fb0bf468543).
 CLOUDFLARE_ACCOUNT_ID = "edd8cf1c48ad414729e72fb0bf468543"
 # D1 database UUID (same as main app wrangler.toml)
-D1_DATABASE_ID = "a214f9da-3577-4ee7-bc50-bc9b9754a79c"
+D1_DATABASE_ID = "66c2da44-c133-4e57-9352-e72637901cb4"
 # Retention: keep daily backups this many days
 BACKUP_RETENTION_DAYS = "30"
 


### PR DESCRIPTION
## Problem

The backup Worker was using the **wrong** D1 database ID:
- Had: `a214f9da-3577-4ee7-bc50-bc9b9754a79c` (old test database)
- Need: `66c2da44-c133-4e57-9352-e72637901cb4` (production database)

This causes the test backup button to fail with:
```
The database a214f9da-3577-4ee7-bc50-bc9b9754a79c could not be found
```

## Fix

Updated `D1_DATABASE_ID` in `workers/backup/wrangler.toml` to match the production database used by the main app.

## Verification

After deployment, the backup Worker will:
- Export from the correct production database
- Test backup button will work properly
- Scheduled backups will backup the right data

🤖 Generated with [Claude Code](https://claude.com/claude-code)