### PR TITLE
fix: Add output_format to D1 export polling in backup Worker

### DIFF
--- a/workers/backup/src/index.ts
+++ b/workers/backup/src/index.ts
@@ -164,7 +164,7 @@ async function exportD1(env: Env): Promise<string> {
     res = await fetch(base, {
       method: "POST",
       headers,
-      body: JSON.stringify({ current_bookmark: bookmark }),
+      body: JSON.stringify({ output_format: "polling", current_bookmark: bookmark }),
     });
     if (!res.ok) throw new Error(`D1 export poll failed: ${res.status}`);
     const poll = (await res.json()) as { result?: ExportResult; success?: boolean };


### PR DESCRIPTION
## Problem

Backup Worker getting 400 error during D1 export polling:
```
D1 export poll failed: 400
```

The D1 export API requires `output_format: "polling"` in **every** request, including polling requests. The Worker was only including it in the initial request, not the polling requests.

## Fix

Added `output_format: "polling"` to the polling request body (line 167).

This is the same fix we made in PR #170 for the manual download endpoint.

## Before
```typescript
body: JSON.stringify({ current_bookmark: bookmark })
```

## After
```typescript
body: JSON.stringify({ output_format: "polling", current_bookmark: bookmark })
```

## Result

After deployment:
- ✅ D1 exports will complete successfully
- ✅ Test Backup Now button will work
- ✅ Scheduled backups will run without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)