### PR TITLE
feat: Add role-specific PIM elevation for multi-role users

### DIFF
--- a/src/components/PimElevationBanner.astro
+++ b/src/components/PimElevationBanner.astro
@@ -6,14 +6,22 @@
 interface Props {
   elevatedUntil: number;
   role?: string;
+  elevatedRole?: string;
 }
 
-const { elevatedUntil } = Astro.props;
+const { elevatedUntil, elevatedRole } = Astro.props;
+
+// Format role label for display
+const roleLabel = elevatedRole
+  ? elevatedRole === 'arb'
+    ? 'ARB'
+    : elevatedRole.charAt(0).toUpperCase() + elevatedRole.slice(1)
+  : 'elevated access';
 ---
 
 <div id="pim-elevation-banner" class="bg-amber-100 border-b border-amber-300 px-4 py-2 flex flex-wrap items-center justify-between gap-2" role="status" aria-live="polite" data-elevated-until={String(elevatedUntil)}>
   <span class="text-amber-900 text-sm font-medium">
-    <span id="pim-elevation-label">Elevated access</span>
+    <span id="pim-elevation-label">Elevated as {roleLabel}</span>
     <span id="pim-elevation-timer" class="ml-2 font-mono">—</span>
   </span>
   <div class="flex items-center gap-3">

--- a/src/components/PortalPage.astro
+++ b/src/components/PortalPage.astro
@@ -46,9 +46,14 @@ const {
 // Get session from Astro.locals (set by middleware) to check elevation status
 const session = Astro.locals.session;
 const sessionElevatedUntil = (session as any)?.elevated_until;
+const sessionAssumedRole = (session as any)?.assumed_role;
 
 // Use prop if provided, otherwise check session
 const actualElevatedUntil = elevatedUntil ?? sessionElevatedUntil ?? null;
+
+// Determine the elevated role to display
+// If assumed_role is set (for admin/arb_board), use that; otherwise use effectiveRole
+const elevatedRole = sessionAssumedRole || effectiveRole;
 
 // Check if PIM elevation banner should be shown
 const now = Date.now();
@@ -80,7 +85,7 @@ const showPimBanner = actualElevatedUntil && actualElevatedUntil > now;
     <!-- Position below fixed header (h-16 = 64px) -->
     {showPimBanner && (
       <div class="mt-16">
-        <PimElevationBanner elevatedUntil={actualElevatedUntil!} role={effectiveRole} />
+        <PimElevationBanner elevatedUntil={actualElevatedUntil!} role={effectiveRole} elevatedRole={elevatedRole} />
       </div>
     )}
 

--- a/src/layouts/BoardLayout.astro
+++ b/src/layouts/BoardLayout.astro
@@ -31,12 +31,16 @@ interface Props {
 const { title, subtitle = '', draftCount = 0, role, session, elevatedUntil, mainWide = false, showRoleBanner = true } = Astro.props;
 const currentPath = Astro.url.pathname;
 const showPimBanner = typeof elevatedUntil === 'number' && elevatedUntil > Date.now();
+
+// Determine the elevated role to display
+// If assumed_role is set (for admin/arb_board), use that; otherwise use role
+const elevatedRole = session?.assumed_role || role;
 ---
 
 <PortalLayout title={`${title} | Board | Member Portal | Crooked Lake Reserve HOA`}>
   <ProtectedPage>
     <div class="min-h-screen portal-theme-bg font-body">
-      {showPimBanner && <PimElevationBanner elevatedUntil={elevatedUntil!} role={role} />}
+      {showPimBanner && <PimElevationBanner elevatedUntil={elevatedUntil!} role={role} elevatedRole={elevatedRole} />}
       <PortalNav currentPath={currentPath} draftCount={draftCount} role={role} staffRole={session?.role ?? role} />
       {showRoleBanner && <PortalElevatedRoleBanner role={role} session={session} />}
       {role === 'admin' ? <AdminNav currentPath={currentPath} /> : role === 'arb' ? <ArbNav currentPath={currentPath} /> : <BoardNav currentPath={currentPath} />}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,8 +52,8 @@ export async function isEmailWhitelisted(
 export const ELEVATED_ROLES = new Set<string>(['arb', 'board', 'arb_board', 'admin']);
 export const VALID_ROLES = new Set<string>(['member', 'arb', 'board', 'arb_board', 'admin']);
 
-/** PIM: 2-hour window for JIT elevated access. */
-export const PIM_ELEVATION_TTL_MS = 2 * 60 * 60 * 1000;
+/** PIM: 1-hour window for JIT elevated access. */
+export const PIM_ELEVATION_TTL_MS = 60 * 60 * 1000;
 
 export function isElevatedRole(role: string): boolean {
   return ELEVATED_ROLES.has(role.toLowerCase());
@@ -490,8 +490,8 @@ export async function createSessionWithElevation(
 export const ASSUMED_ROLES = ['board', 'arb'] as const;
 export type AdminAssumedRole = (typeof ASSUMED_ROLES)[number];
 
-/** TTL for assumed role (2 hours). After this, user falls back to admin/arb_board until they assume again or drop. */
-export const ASSUMED_ROLE_TTL_MS = 2 * 60 * 60 * 1000;
+/** TTL for assumed role (1 hour). After this, user falls back to admin/arb_board until they assume again or drop. */
+export const ASSUMED_ROLE_TTL_MS = 60 * 60 * 1000;
 
 /**
  * Re-issue session cookie with assumed_role set or cleared (admin or arb_board only). Caller must set the cookie on response and log the action.

--- a/src/lib/auth/middleware.ts
+++ b/src/lib/auth/middleware.ts
@@ -68,10 +68,13 @@ export async function validateSession(
     }
 
     // Manually fetch custom session attributes (Lucia D1 adapter doesn't include them)
-    // This includes elevated_until for PIM (Privileged Identity Management)
+    // This includes elevated_until, assumed_role, assumed_at, assumed_until for PIM
     if (result.session && dbSession) {
       (result.session as any).elevated_until = dbSession.elevated_until;
-      console.log('[VALIDATE DEBUG] Added elevated_until to session:', dbSession.elevated_until);
+      (result.session as any).assumed_role = dbSession.assumed_role;
+      (result.session as any).assumed_at = dbSession.assumed_at;
+      (result.session as any).assumed_until = dbSession.assumed_until;
+      console.log('[VALIDATE DEBUG] Added PIM attributes - elevated_until:', dbSession.elevated_until, 'assumed_role:', dbSession.assumed_role);
     }
 
     return result;

--- a/src/lib/lucia/index.ts
+++ b/src/lib/lucia/index.ts
@@ -16,6 +16,17 @@ export interface DatabaseUserAttributes {
   status: string;
 }
 
+export interface DatabaseSessionAttributes {
+  elevated_until?: number | null;
+  assumed_role?: string | null;
+  assumed_at?: number | null;
+  assumed_until?: number | null;
+  fingerprint?: string | null;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  created_at?: number | null;
+}
+
 /**
  * Determine if we're running in production based on environment.
  * Checks common environment indicators.
@@ -95,5 +106,6 @@ declare module 'lucia' {
   interface Register {
     Lucia: ReturnType<typeof createLucia>;
     DatabaseUserAttributes: DatabaseUserAttributes;
+    DatabaseSessionAttributes: DatabaseSessionAttributes;
   }
 }

--- a/src/pages/api/pim/drop.ts
+++ b/src/pages/api/pim/drop.ts
@@ -46,16 +46,25 @@ export async function POST(context: APIContext): Promise<Response> {
   }
 
   try {
-    // Clear elevation from session
+    // Get current assumed_role before clearing (for logging)
+    const dbSession = await env.DB
+      .prepare('SELECT assumed_role FROM sessions WHERE id = ?')
+      .bind(session.id)
+      .first<{ assumed_role: string | null }>();
+
+    const assumedRole = dbSession?.assumed_role;
+
+    // Clear elevation and assumed role from session
     await env.DB
-      .prepare('UPDATE sessions SET elevated_until = NULL WHERE id = ?')
+      .prepare('UPDATE sessions SET elevated_until = NULL, assumed_role = NULL, assumed_at = NULL, assumed_until = NULL WHERE id = ?')
       .bind(session.id)
       .run();
 
-    // Log the drop action
+    // Log the drop action with the specific role that was dropped
+    const loggedRole = assumedRole || userRole;
     await insertPimElevationLog(env.DB, {
       email: user.email,
-      role: userRole,
+      role: loggedRole,
       action: 'drop',
       expires_at: null,
     });

--- a/src/pages/api/pim/elevate.ts
+++ b/src/pages/api/pim/elevate.ts
@@ -50,7 +50,7 @@ export async function POST(context: APIContext): Promise<Response> {
   }
 
   // Parse request body
-  let body: { password?: string };
+  let body: { password?: string; targetRole?: string };
   try {
     body = await context.request.json();
   } catch {
@@ -63,7 +63,7 @@ export async function POST(context: APIContext): Promise<Response> {
     });
   }
 
-  const { password } = body;
+  const { password, targetRole } = body;
 
   // Require password for re-authentication
   if (!password || typeof password !== 'string') {
@@ -106,20 +106,66 @@ export async function POST(context: APIContext): Promise<Response> {
       });
     }
 
+    // Validate and determine target role for elevation
+    let effectiveTargetRole: string | null = null;
+
+    if (userRole === 'admin') {
+      // Admin can elevate to admin, board, or arb
+      const validTargets = ['admin', 'board', 'arb'];
+      if (targetRole && validTargets.includes(targetRole.toLowerCase())) {
+        effectiveTargetRole = targetRole.toLowerCase();
+      } else {
+        return new Response(JSON.stringify({
+          error: 'Admin must specify target role: admin, board, or arb',
+          success: false
+        }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    } else if (userRole === 'arb_board') {
+      // ARB+Board can elevate to board or arb (one at a time)
+      const validTargets = ['board', 'arb'];
+      if (targetRole && validTargets.includes(targetRole.toLowerCase())) {
+        effectiveTargetRole = targetRole.toLowerCase();
+      } else {
+        return new Response(JSON.stringify({
+          error: 'Board+ARB must specify target role: board or arb',
+          success: false
+        }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+    // For single-role users (board, arb), no target role needed - they elevate to their only role
+
     // Password valid - grant elevation
     const elevatedUntil = Date.now() + ELEVATION_DURATION_MS;
 
-    // Update session with elevation
-    await env.DB
-      .prepare('UPDATE sessions SET elevated_until = ? WHERE id = ?')
-      .bind(elevatedUntil, session.id)
-      .run();
+    // Determine assumed_role for database and session
+    // Admin and arb_board need assumed_role set; single-role users don't
+    const assumedRole = (userRole === 'admin' || userRole === 'arb_board') ? effectiveTargetRole : null;
 
-    // Log successful elevation
+    // Update session with elevation and assumed_role if applicable
+    if (assumedRole) {
+      await env.DB
+        .prepare('UPDATE sessions SET elevated_until = ?, assumed_role = ?, assumed_at = ?, assumed_until = ? WHERE id = ?')
+        .bind(elevatedUntil, assumedRole, elevatedUntil, elevatedUntil, session.id)
+        .run();
+    } else {
+      await env.DB
+        .prepare('UPDATE sessions SET elevated_until = ? WHERE id = ?')
+        .bind(elevatedUntil, session.id)
+        .run();
+    }
+
+    // Log successful elevation with the specific role that was elevated to
     const expiresAtIso = new Date(elevatedUntil).toISOString();
+    const loggedRole = effectiveTargetRole || userRole;
     await insertPimElevationLog(env.DB, {
       email: user.email,
-      role: userRole,
+      role: loggedRole,
       action: 'elevate',
       expires_at: expiresAtIso,
     });
@@ -128,6 +174,7 @@ export async function POST(context: APIContext): Promise<Response> {
       success: true,
       elevated_until: elevatedUntil,
       expires_in_minutes: 60,
+      elevated_role: loggedRole,
     }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/pim/extend.ts
+++ b/src/pages/api/pim/extend.ts
@@ -51,11 +51,11 @@ export async function POST(context: APIContext): Promise<Response> {
   }
 
   try {
-    // Get current elevation status
+    // Get current elevation status including assumed_role
     const dbSession = await env.DB
-      .prepare('SELECT elevated_until FROM sessions WHERE id = ?')
+      .prepare('SELECT elevated_until, assumed_role, assumed_until FROM sessions WHERE id = ?')
       .bind(session.id)
-      .first<{ elevated_until: number | null }>();
+      .first<{ elevated_until: number | null; assumed_role: string | null; assumed_until: number | null }>();
 
     if (!dbSession || !dbSession.elevated_until) {
       return new Response(JSON.stringify({
@@ -99,16 +99,25 @@ export async function POST(context: APIContext): Promise<Response> {
     const newExpiration = currentExpiration + EXTENSION_DURATION_MS;
 
     // Update session with new expiration
-    await env.DB
-      .prepare('UPDATE sessions SET elevated_until = ? WHERE id = ?')
-      .bind(newExpiration, session.id)
-      .run();
+    // Also extend assumed_until if user has an assumed role
+    if (dbSession.assumed_role && dbSession.assumed_until) {
+      await env.DB
+        .prepare('UPDATE sessions SET elevated_until = ?, assumed_until = ? WHERE id = ?')
+        .bind(newExpiration, newExpiration, session.id)
+        .run();
+    } else {
+      await env.DB
+        .prepare('UPDATE sessions SET elevated_until = ? WHERE id = ?')
+        .bind(newExpiration, session.id)
+        .run();
+    }
 
-    // Log the extension
+    // Log the extension with the specific role (use assumed_role if present)
     const expiresAtIso = new Date(newExpiration).toISOString();
+    const loggedRole = dbSession.assumed_role || userRole;
     await insertPimElevationLog(env.DB, {
       email: user.email,
-      role: userRole,
+      role: loggedRole,
       action: 'elevate', // Using 'elevate' to represent extension
       expires_at: expiresAtIso,
     });

--- a/src/pages/api/test/create-session.ts
+++ b/src/pages/api/test/create-session.ts
@@ -69,7 +69,7 @@ export async function POST(context: APIContext): Promise<Response> {
     // Add role assumption if requested
     if (assumeRole) {
       const assumedAt = Date.now();
-      const assumedUntil = Date.now() + (2 * 60 * 60 * 1000); // 2 hours
+      const assumedUntil = Date.now() + (60 * 60 * 1000); // 1 hour
       await env.DB
         .prepare('UPDATE sessions SET assumed_role = ?, assumed_at = ?, assumed_until = ? WHERE id = ?')
         .bind(assumeRole, assumedAt, assumedUntil, session.id)

--- a/src/pages/portal/assume-role-help.astro
+++ b/src/pages/portal/assume-role-help.astro
@@ -64,8 +64,8 @@ const isElevated = ['admin', 'arb_board', 'board', 'arb'].includes(effectiveRole
           </section>
 
         <section>
-          <h2 class="text-xl font-heading font-semibold text-clr-green mt-6 mb-3">Timeout (2 hours)</h2>
-            <p>After you assume a role, it automatically <strong>expires after 2 hours</strong>. The banner shows something like “Role expires in ~1h 45m.” When the time runs out, you’re no longer acting as that role. You can <strong>drop the role</strong> at any time. Before assuming the <strong>other</strong> role (e.g. switch from Board to ARB), you must drop or wait for the current role to expire.</p>
+          <h2 class="text-xl font-heading font-semibold text-clr-green mt-6 mb-3">Timeout (1 hour)</h2>
+            <p>After you assume a role, it automatically <strong>expires after 1 hour</strong>. The banner shows the remaining time. When the time runs out, you're no longer acting as that role. You can <strong>drop the role</strong> at any time. Before assuming the <strong>other</strong> role (e.g. switch from Board to ARB), you must drop or wait for the current role to expire.</p>
           </section>
 
         <section>

--- a/src/pages/portal/dashboard.astro
+++ b/src/pages/portal/dashboard.astro
@@ -90,6 +90,10 @@ const hasNewNotices = recentVendorsCount > 0 || recentOwnersCount > 0;
 const arbBadgeCount = isStaffRole ? arbCounts.pending : draftCount;
 const showPimBanner = isStaffRole && typeof session.elevated_until === 'number' && session.elevated_until > Date.now();
 
+// Determine the elevated role to display
+// If assumed_role is set (for admin/arb_board), use that; otherwise use effectiveRole
+const elevatedRole = (session as any)?.assumed_role || effectiveRole;
+
 // Dismissals: "Mark as read" hides a notice for 7 days
 const dismissedSet = db ? await getDismissedKeys(db, email) : new Set<string>();
 const showStaffOutstanding = hasStaffWhitelistRole && (arbCounts.in_review > 0 || arbCounts.pending > 0 || pendingVendorCount > 0) && !dismissedSet.has('staff_outstanding');
@@ -127,7 +131,7 @@ const showActionNeededBanner = showActionFeedback || showActionMaintenance || sh
           <!-- PIM Elevation Banner -->
           {showPimBanner && (
             <div class="mb-6">
-              <PimElevationBanner elevatedUntil={session.elevated_until!} role={effectiveRole} />
+              <PimElevationBanner elevatedUntil={session.elevated_until!} role={effectiveRole} elevatedRole={elevatedRole} />
             </div>
           )}
 
@@ -149,7 +153,7 @@ const showActionNeededBanner = showActionFeedback || showActionMaintenance || sh
                     {canRequestElevation ? (
                       <>
                         <p class="text-sm text-amber-800 mb-3">
-                          You're viewing the portal as a regular member. Click "Request elevated access" in the sidebar to use board or ARB tools for 2 hours.
+                          You're viewing the portal as a regular member. Click "Request elevated access" in the sidebar to use board or ARB tools for 1 hour.
                         </p>
                         <button type="button" id="pim-elevate-btn" class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-lg font-medium text-sm transition-colors">
                           Request elevated access

--- a/src/pages/portal/faq.astro
+++ b/src/pages/portal/faq.astro
@@ -53,9 +53,9 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
           </section>
 
           <section class="bg-white rounded-2xl border border-gray-200 p-6 sm:p-8 portal-theme-card">
-        <h2 class="text-2xl font-heading font-bold text-clr-green mb-3">Why don’t I see Board or ARB links?</h2>
+        <h2 class="text-2xl font-heading font-bold text-clr-green mb-3">Why don't I see Board or ARB links?</h2>
             <p class="text-gray-700 text-base leading-relaxed">
-              Board and ARB tools are only visible when you have <strong>elevated access</strong>. If you’re a board or ARB member, you normally see the same portal as everyone else; when you need to use board tools (record payments, ARB dashboard, etc.), go to the <strong>Dashboard</strong> and click <strong>Request elevated access</strong>. You get a short window of access, then you’re back to the normal view. Use <strong>Drop access</strong> when you’re done.
+              Board and ARB tools are only visible when you have <strong>elevated access</strong>. If you're a board or ARB member, you normally see the same portal as everyone else; when you need to use board tools (record payments, ARB dashboard, etc.), go to the <strong>Dashboard</strong> and click <strong>Request elevated access</strong>. You get <strong>1 hour</strong> of elevated access, then you're back to the normal view. Use <strong>Drop access</strong> when you're done.
             </p>
           </section>
 

--- a/src/pages/portal/request-elevated-access.astro
+++ b/src/pages/portal/request-elevated-access.astro
@@ -68,6 +68,87 @@ const returnLabel = returnParam && returnParam.startsWith('/board') ? 'Board' : 
 
         <!-- Elevation Request Form -->
         <form id="pim-elevate-form" class="space-y-4">
+          {/* Role selection for users with multiple roles */}
+          {(whitelistRole === 'admin' || whitelistRole === 'arb_board') && (
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-3">
+                Select role to elevate to <span class="text-red-600">*</span>
+              </label>
+              <div class="space-y-2">
+                {whitelistRole === 'admin' && (
+                  <>
+                    <label class="flex items-center p-3 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="targetRole"
+                        value="admin"
+                        required
+                        class="w-4 h-4 text-clr-green focus:ring-clr-green border-gray-300"
+                      />
+                      <span class="ml-3 text-sm">
+                        <strong class="text-gray-900">Admin</strong>
+                        <span class="block text-gray-600 text-xs mt-0.5">Site administration, user management, and settings</span>
+                      </span>
+                    </label>
+                    <label class="flex items-center p-3 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="targetRole"
+                        value="board"
+                        class="w-4 h-4 text-clr-green focus:ring-clr-green border-gray-300"
+                      />
+                      <span class="ml-3 text-sm">
+                        <strong class="text-gray-900">Board</strong>
+                        <span class="block text-gray-600 text-xs mt-0.5">Board operations, directory, meetings, dues</span>
+                      </span>
+                    </label>
+                    <label class="flex items-center p-3 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="targetRole"
+                        value="arb"
+                        class="w-4 h-4 text-clr-green focus:ring-clr-green border-gray-300"
+                      />
+                      <span class="ml-3 text-sm">
+                        <strong class="text-gray-900">ARB</strong>
+                        <span class="block text-gray-600 text-xs mt-0.5">Architectural Review Board operations</span>
+                      </span>
+                    </label>
+                  </>
+                )}
+                {whitelistRole === 'arb_board' && (
+                  <>
+                    <label class="flex items-center p-3 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="targetRole"
+                        value="board"
+                        required
+                        class="w-4 h-4 text-clr-green focus:ring-clr-green border-gray-300"
+                      />
+                      <span class="ml-3 text-sm">
+                        <strong class="text-gray-900">Board</strong>
+                        <span class="block text-gray-600 text-xs mt-0.5">Board operations, directory, meetings, dues</span>
+                      </span>
+                    </label>
+                    <label class="flex items-center p-3 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="targetRole"
+                        value="arb"
+                        class="w-4 h-4 text-clr-green focus:ring-clr-green border-gray-300"
+                      />
+                      <span class="ml-3 text-sm">
+                        <strong class="text-gray-900">ARB</strong>
+                        <span class="block text-gray-600 text-xs mt-0.5">Architectural Review Board operations</span>
+                      </span>
+                    </label>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
           <div>
             <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
               Confirm your password <span class="text-red-600">*</span>
@@ -140,15 +221,24 @@ const returnLabel = returnParam && returnParam.startsWith('/board') ? 'Board' : 
           return;
         }
 
+        // Get selected target role (if applicable)
+        var targetRoleInput = document.querySelector('input[name="targetRole"]:checked');
+        var targetRole = targetRoleInput ? targetRoleInput.value : null;
+
         var b = /** @type {HTMLButtonElement} */ (btn);
         b.disabled = true;
         b.textContent = 'Requesting access...';
+
+        var requestBody = { password: password };
+        if (targetRole) {
+          requestBody.targetRole = targetRole;
+        }
 
         fetch('/api/pim/elevate', {
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ password: password })
+          body: JSON.stringify(requestBody)
         })
           .then(function (r) {
             return r.json().then(function (data) {


### PR DESCRIPTION
## Summary
Adds role-specific PIM elevation allowing users with multiple roles (admin, arb_board) to choose which specific role to elevate to when requesting elevated access.

## Changes

### User Experience
- **Admin users** can now select: admin, board, or arb
- **ARB+Board users** can now select: board or arb
- Only one role can be elevated at a time
- PIM banner displays the specific elevated role (e.g., "Elevated as Board")
- Updated elevation duration from **2 hours to 1 hour** across all UI and documentation

### API Updates
- `/api/pim/elevate`: Now accepts `targetRole` parameter and sets `assumed_role`
- `/api/pim/extend`: Extends `assumed_until` when extending elevation
- `/api/pim/drop`: Clears all assumed_role fields when dropping elevation

### UI Updates
- Added radio button selection on `/portal/request-elevated-access` page
- Users with multiple roles must choose which role to elevate to
- Updated PIM banner component to show specific elevated role
- Updated all duration references from "2 hours" to "1 hour"

### Database & Types
- Leverages existing `assumed_role`, `assumed_at`, `assumed_until` columns in sessions table
- Middleware now fetches and includes assumed role attributes
- Added `DatabaseSessionAttributes` type for Lucia session attributes

### Documentation
- Updated FAQ, dashboard, and help pages with 1-hour duration
- Updated auth.ts constants (`PIM_ELEVATION_TTL_MS`, `ASSUMED_ROLE_TTL_MS`) to reflect 1-hour TTL

## Test Plan
- [ ] Admin user can select and elevate to admin, board, or arb role
- [ ] ARB+Board user can select and elevate to board or arb role
- [ ] PIM banner shows the correct elevated role label
- [ ] Elevation expires after 1 hour
- [ ] Extension extends the assumed role timeout
- [ ] Drop clears all assumed role fields
- [ ] All UI text correctly shows "1 hour" duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)