### PR TITLE
fix: Remove duplicate public-doc-message div

### DIFF
--- a/src/pages/board/public-documents.astro
+++ b/src/pages/board/public-documents.astro
@@ -56,8 +56,7 @@ function formatDate(s: string | null): string {
     <AdminNav currentPath="/board/public-documents" />
 
     <div id="public-doc-message" class="hidden mb-4 p-4 rounded-xl border" role="status" aria-live="polite" aria-atomic="true"></div>
-<div id="public-doc-message" class="hidden mb-4 p-4 rounded-xl border" role="status" aria-live="polite" aria-atomic="true"></div>
-  <div class="mb-8 p-4 rounded-xl bg-amber-50 border border-amber-200 text-amber-900" role="alert">
+    <div class="mb-8 p-4 rounded-xl bg-amber-50 border border-amber-200 text-amber-900" role="alert">
     <p class="font-semibold">These documents are publicly accessible.</p>
     <p class="text-base mt-1">Anyone can view and download them from the <a href="/documents" class="underline font-medium" target="_blank" rel="noopener noreferrer">Documents page <span class="text-amber-800/80">(opens in new tab)</span></a> (no login required). Only upload files you intend to make public.</p>
   </div>


### PR DESCRIPTION
Fixes duplicate div accidentally created during previous fix.

## Changes
- Removed duplicate public-doc-message div element
- File now has clean structure without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)