### PR TITLE
debug: Add extensive logging to public document upload endpoint

### DIFF
--- a/src/pages/api/public-document-upload.astro
+++ b/src/pages/api/public-document-upload.astro
@@ -77,10 +77,27 @@ if (!slug || !isManagedPublicDocSlug(slug)) {
 
 // Get effective role considering PIM elevation and assumed roles
 // The session from Astro.locals includes database attributes (assumed_role, elevated_until)
+console.log('[PUBLIC-DOC] Session data:', {
+  userId: (session as any).userId,
+  elevated_until: (session as any).elevated_until,
+  assumed_role: (session as any).assumed_role,
+  assumed_until: (session as any).assumed_until
+});
+console.log('[PUBLIC-DOC] User role:', user.role);
+
 const effectiveRole = getEffectiveRole(session as any);
+console.log('[PUBLIC-DOC] Effective role:', effectiveRole);
+
 const isBoard = effectiveRole === 'board' || effectiveRole === 'admin' || effectiveRole === 'arb_board';
 const canEditBoardDocs = isBoard;
 const canEditArbForm = isBoard || effectiveRole === 'arb';
+
+console.log('[PUBLIC-DOC] Permissions:', {
+  effectiveRole,
+  isBoard,
+  canEditBoardDocs,
+  canEditArbForm
+});
 
 const allowedBoard = BOARD_ONLY_SLUGS.includes(slug as typeof BOARD_ONLY_SLUGS[number]);
 const isArbForm = slug === ARB_FORM_SLUG;


### PR DESCRIPTION
## Summary
- Add detailed console logging to trace session attributes and permission calculations in public document upload endpoint
- Will help diagnose why users with assumed board role are getting 403 Forbidden errors

## Changes
- Added logging for session data (userId, elevated_until, assumed_role, assumed_until)
- Added logging for user base role
- Added logging for calculated effectiveRole from getEffectiveRole()
- Added logging for permission flags (isBoard, canEditBoardDocs, canEditArbForm)

## Test plan
- [ ] Deploy to production
- [ ] Have user with admin/arb_board role request elevated access
- [ ] Have user select "Board" as target role
- [ ] Attempt to upload a public document
- [ ] Check browser console and server logs for debug output
- [ ] Verify session attributes and effectiveRole calculation

## Notes
This is temporary debug logging to diagnose issue #192. Once the root cause is identified and fixed, these console.log statements should be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)