### PR TITLE
fix: Add user role to session object for getEffectiveRole()

### DIFF
--- a/src/lib/auth/middleware.ts
+++ b/src/lib/auth/middleware.ts
@@ -69,12 +69,14 @@ export async function validateSession(
 
     // Manually fetch custom session attributes (Lucia D1 adapter doesn't include them)
     // This includes elevated_until, assumed_role, assumed_at, assumed_until for PIM
+    // Also add the user's base role so getEffectiveRole() can access it
     if (result.session && dbSession) {
+      (result.session as any).role = result.user.role;
       (result.session as any).elevated_until = dbSession.elevated_until;
       (result.session as any).assumed_role = dbSession.assumed_role;
       (result.session as any).assumed_at = dbSession.assumed_at;
       (result.session as any).assumed_until = dbSession.assumed_until;
-      console.log('[VALIDATE DEBUG] Added PIM attributes - elevated_until:', dbSession.elevated_until, 'assumed_role:', dbSession.assumed_role);
+      console.log('[VALIDATE DEBUG] Added PIM attributes - role:', result.user.role, 'elevated_until:', dbSession.elevated_until, 'assumed_role:', dbSession.assumed_role);
     }
 
     return result;


### PR DESCRIPTION
## Summary
- Fix permission check failure when users assume board/arb roles via PIM elevation
- Middleware now adds user's base role to session object so getEffectiveRole() can read it

## Problem
User reported: "I have assumed the board role, but says I'm not in that role"

From debug logs, the session had correct data:
- `assumed_role: "board"` ✅
- `assumed_until: valid timestamp` ✅
- `elevated_until: valid timestamp` ✅

But `getEffectiveRole()` was returning `"member"` instead of `"board"`.

## Root Cause
The middleware was adding PIM attributes (elevated_until, assumed_role, assumed_until) to the session object, but NOT the user's base role. When `getEffectiveRole()` tried to read `session.role`, it got `undefined`, defaulted to `'member'`, checked `ELEVATED_ROLES.has('member')` (false), and immediately returned `'member'` without ever checking the assumed_role.

## Solution
Added `(result.session as any).role = result.user.role;` in middleware so the session object includes the user's base role. Now getEffectiveRole() can:
1. Read session.role correctly (e.g., "admin")
2. Verify it's in ELEVATED_ROLES
3. Check if elevation is still valid
4. Return the assumed_role ("board") when appropriate

## Test plan
- [x] Deploy to production
- [ ] User assumes board role via PIM elevation
- [ ] Attempt to upload a public document
- [ ] Should succeed with 200 OK instead of 403 Forbidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)