### PR TITLE
debug: Add logging and validation for public document database update

### DIFF
--- a/src/pages/api/public-document-upload.astro
+++ b/src/pages/api/public-document-upload.astro
@@ -142,12 +142,32 @@ const ext = file.name.includes('.') ? file.name.split('.').pop()?.toLowerCase() 
 const safeExt = ['pdf', 'docx', 'doc'].includes(ext) ? ext : 'pdf';
 const fileKey = `public-docs/${slug}.${safeExt}`;
 
+console.log('[PUBLIC-DOC] Uploading to R2:', { fileKey, contentType: file.type, size: file.size });
 const buf = await file.arrayBuffer();
 await r2.put(fileKey, buf, {
   httpMetadata: { contentType: file.type },
 });
+console.log('[PUBLIC-DOC] R2 upload successful');
 
-await setPublicDocumentFile(db, slug, fileKey, file.type, user.email, effectiveRole);
+console.log('[PUBLIC-DOC] Updating database:', { slug, fileKey, contentType: file.type, email: user.email, role: effectiveRole });
+const dbResult = await db
+  .prepare(
+    `UPDATE public_documents SET file_key = ?, content_type = ?, updated_at = datetime('now'), updated_by_email = ?, updated_by_role = ? WHERE slug = ?`
+  )
+  .bind(fileKey, file.type, user.email, effectiveRole, slug)
+  .run();
+console.log('[PUBLIC-DOC] Database update result:', { success: dbResult.success, rowsAffected: dbResult.meta?.changes });
+
+if (!dbResult.success || dbResult.meta?.changes === 0) {
+  console.error('[PUBLIC-DOC] Database update failed or no rows affected');
+  return new Response(
+    JSON.stringify({
+      error: 'Database update failed',
+      debug: { success: dbResult.success, rowsAffected: dbResult.meta?.changes }
+    }),
+    { status: 500, headers: { 'Content-Type': 'application/json' } }
+  );
+}
 
 return new Response(
   JSON.stringify({


### PR DESCRIPTION
## Summary
- Add detailed logging for R2 upload and database update operations
- Validate that database update actually affects rows
- Return 500 error if no rows affected

## Problem
User reports: "it says the file has uploaded, but doesn't seem to be working. It doesn't keep the file uploaded, It seems to upload and then not save."

The API returns 200 OK but after page reload, the new file isn't showing. This suggests the database UPDATE is failing silently (affecting 0 rows).

## Changes
1. Added logging before/after R2 upload with file details
2. Added logging for database update parameters
3. Changed from `setPublicDocumentFile()` helper to inline UPDATE query so we can check the result
4. Added validation: if `dbResult.success === false` or `dbResult.meta.changes === 0`, return 500 error
5. Log database result (success, rows affected)

## Expected Outcome
This will reveal whether:
- The database UPDATE is succeeding but affecting 0 rows (row doesn't exist)
- The R2 upload is failing
- Something else is wrong

If rows affected = 0, we'll need to check if the `public_documents` table has rows for these slugs, or if we need to INSERT instead of UPDATE.

## Test plan
- [x] Deploy to production
- [ ] User attempts to upload a public document
- [ ] Check logs for database update result
- [ ] If rows affected = 0, check database schema and seed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)