### PR TITLE
debug: Add logging to show what database returns on page load

### DIFF
--- a/src/pages/board/public-documents.astro
+++ b/src/pages/board/public-documents.astro
@@ -21,6 +21,15 @@ const { email, role, name } = session;
 const badges = await getPortalBadgeCounts(db, email, role, name);
 const docs = db ? await listPublicDocuments(db) : [];
 
+console.log('[PUBLIC-DOCS-PAGE] Loaded documents:', docs.map(d => ({
+  slug: d.slug,
+  title: d.title,
+  hasFileKey: !!d.file_key,
+  file_key: d.file_key,
+  updated_at: d.updated_at,
+  updated_by_email: d.updated_by_email
+})));
+
 
 function canEdit(slug: string): boolean {
   if (BOARD_ONLY_SLUGS.includes(slug as typeof BOARD_ONLY_SLUGS[number])) return isBoard;


### PR DESCRIPTION
## Summary
- Add logging to board/public-documents.astro to show what listPublicDocuments() returns
- Will help diagnose why uploads succeed but changes don't persist after reload

## Problem
Upload logs show complete success:
- R2 upload: ✅ successful
- Database update: ✅ success, rowsAffected: 1
- Response: 200 OK

But user reports the file doesn't persist after page reload.

## Theory
Possible D1 read-after-write consistency issue, or the page is showing cached data. This logging will show what the database actually returns when the page loads after upload.

## Test plan
- [x] Deploy to production
- [ ] User uploads a document
- [ ] After page reload, check logs for `[PUBLIC-DOCS-PAGE] Loaded documents:`
- [ ] Verify if the uploaded document shows `hasFileKey: true` and correct file_key

🤖 Generated with [Claude Code](https://claude.com/claude-code)