### PR TITLE
debug: Add logging to diagnose 404 errors when downloading public documents

### DIFF
--- a/src/pages/api/public-doc-file.astro
+++ b/src/pages/api/public-doc-file.astro
@@ -8,7 +8,9 @@ export const prerender = false;
 import { getPublicDocument } from '../../lib/public-documents-db';
 
 const slug = Astro.url.searchParams.get('slug')?.trim()?.toLowerCase();
+console.log('[PUBLIC-DOC-FILE] Request for slug:', slug);
 if (!slug) {
+  console.log('[PUBLIC-DOC-FILE] Missing slug - returning 400');
   return new Response('Missing slug', { status: 400 });
 }
 
@@ -18,16 +20,22 @@ const db = env?.DB;
 const r2 = env?.CLOURHOA_FILES;
 
 if (!db || !r2) {
+  console.log('[PUBLIC-DOC-FILE] Missing db or r2 - returning 503');
   return new Response('Service unavailable', { status: 503 });
 }
 
 const row = await getPublicDocument(db, slug);
+console.log('[PUBLIC-DOC-FILE] Database result:', { slug, hasRow: !!row, file_key: row?.file_key, content_type: row?.content_type });
 if (!row?.file_key) {
+  console.log('[PUBLIC-DOC-FILE] No file_key in database - returning 404');
   return new Response('Not found', { status: 404 });
 }
 
+console.log('[PUBLIC-DOC-FILE] Fetching from R2:', row.file_key);
 const object = await r2.get(row.file_key);
+console.log('[PUBLIC-DOC-FILE] R2 result:', { hasObject: !!object, key: row.file_key });
 if (!object) {
+  console.log('[PUBLIC-DOC-FILE] Object not found in R2 - returning 404');
   return new Response('Not found', { status: 404 });
 }
 


### PR DESCRIPTION
## Summary
- Add detailed logging to /api/public-doc-file endpoint
- Will help diagnose why user gets 404 when downloading ARB request form

## Problem
Upload works correctly (database and R2 both successful), but downloading from public /documents page returns 404.

## Logging Added
- Request slug parameter
- Database query result (row found, file_key value)
- R2 fetch attempt and result

## Expected Outcome
This will reveal whether the 404 is because:
- The database query isn't finding the row
- The file_key isn't set in the database
- The R2 object doesn't exist at that key
- There's a binding or permission issue

## Test plan
- [x] Deploy to production
- [ ] User tries to download ARB request form from /documents page
- [ ] Check logs for the failure point

🤖 Generated with [Claude Code](https://claude.com/claude-code)