### PR TITLE
debug: Add logging to documents page override logic

### DIFF
--- a/src/pages/documents.astro
+++ b/src/pages/documents.astro
@@ -24,11 +24,13 @@ const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 const db = env?.DB;
 const publicOverrides = db ? await listPublicDocuments(db) : [];
+console.log('[DOCUMENTS-PAGE] Public overrides from DB:', publicOverrides.map(r => ({ slug: r.slug, hasFileKey: !!r.file_key, file_key: r.file_key })));
 const overrideBySlug = Object.fromEntries(
   publicOverrides
     .filter((r) => r.file_key)
     .map((r) => [r.slug, { slug: r.slug, file_key: r.file_key, content_type: r.content_type }])
 );
+console.log('[DOCUMENTS-PAGE] Override map keys:', Object.keys(overrideBySlug));
 
 const keyRules = [
   { title: 'Quarterly dues', detail: 'Due on the 1st of January, April, July, and October.' },
@@ -90,6 +92,9 @@ const keyRules = [
               const override = slug ? overrideBySlug[slug] : null;
               const linkUrl = override?.file_key ? `/api/public-doc-file?slug=${encodeURIComponent(slug!)}` : doc.data.fileUrl;
               const isPdf = linkUrl.toLowerCase().includes('.pdf') || (override?.content_type?.toLowerCase().includes('pdf'));
+              if (slug === 'arb-request-form') {
+                console.log('[DOCUMENTS-PAGE] ARB form URL construction:', { slug, hasOverride: !!override, override, linkUrl });
+              }
               return (
               <div class="card-hover bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
                 <h3 class="text-xl font-heading font-semibold text-clr-green mb-2">{doc.data.title}</h3>


### PR DESCRIPTION
## Summary
- Add logging to /documents page to trace override logic
- Will reveal why uploaded files aren't being served

## Problem
User uploaded ARB request form successfully (database has file_key set correctly), but the public /documents page still links to the old static file instead of the API endpoint.

Expected URL: `/api/public-doc-file?slug=arb-request-form`
Actual URL: `/docs/CLR-ARB-Request-Form-2026.docx`

## Logging Added
- Public overrides loaded from database
- Override map keys after filtering
- URL construction details for ARB request form

## Test plan
- [x] Deploy to production
- [ ] User visits /documents page
- [ ] Check logs to see if override is found and URL is constructed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)