### PR TITLE
debug: Add logging to trace content collection document loading

### DIFF
--- a/src/pages/documents.astro
+++ b/src/pages/documents.astro
@@ -6,7 +6,9 @@ import { getCollection } from 'astro:content';
 import { listPublicDocuments } from '../lib/public-documents-db';
 
 const allDocuments = await getCollection('documents');
+console.log('[DOCUMENTS-PAGE] All documents:', allDocuments.map(d => ({ slug: d.data.slug, title: d.data.title, category: d.data.category, published: d.data.published })));
 const publishedDocuments = allDocuments.filter((item) => item.data.published);
+console.log('[DOCUMENTS-PAGE] Published:', publishedDocuments.map(d => d.data.slug));
 
 const documentsByCategory = publishedDocuments.reduce((acc, doc) => {
   const category = doc.data.category;
@@ -16,6 +18,7 @@ const documentsByCategory = publishedDocuments.reduce((acc, doc) => {
   acc[category].push(doc);
   return acc;
 }, {} as Record<string, typeof publishedDocuments>);
+console.log('[DOCUMENTS-PAGE] By category:', Object.fromEntries(Object.entries(documentsByCategory).map(([cat, docs]) => [cat, docs.map(d => d.data.slug)])));
 
 const categories = ['Governing Documents', 'Policies', 'Forms', 'Other'] as const;
 


### PR DESCRIPTION
## Summary
- Add logging to see what documents are loaded from Astro content collection
- Diagnose why override isn't being applied even though override map is correct

## Problem
Override map has `arb-request-form` correctly, but the link still points to old file. The URL construction log never executes, which means the document isn't being rendered.

## Test plan
- [x] Deploy to production
- [ ] User visits /documents page
- [ ] Check logs for content collection documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)