### PR TITLE
fix: Use auto-generated doc.slug for override matching on documents page

### DIFF
--- a/src/pages/documents.astro
+++ b/src/pages/documents.astro
@@ -92,13 +92,11 @@ const keyRules = [
           <h2 class="text-2xl font-heading font-bold text-clr-green mb-6">{category}</h2>
           <div class="grid md:grid-cols-2 gap-6">
             {docs.map((doc) => {
-              const slug = doc.data.slug;
+              const slug = doc.slug; // Use auto-generated slug from filename, not doc.data.slug
               const override = slug ? overrideBySlug[slug] : null;
               const linkUrl = override?.file_key ? `/api/public-doc-file?slug=${encodeURIComponent(slug!)}` : doc.data.fileUrl;
               const isPdf = linkUrl.toLowerCase().includes('.pdf') || (override?.content_type?.toLowerCase().includes('pdf'));
-              if (slug === 'arb-request-form') {
-                console.log('[DOCUMENTS-PAGE] ARB form URL construction:', { slug, hasOverride: !!override, override, linkUrl });
-              }
+              console.log('[DOCUMENTS-PAGE] Rendering doc:', { slug, hasOverride: !!override, linkUrl });
               return (
               <div class="card-hover bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
                 <h3 class="text-xl font-heading font-semibold text-clr-green mb-2">{doc.data.title}</h3>


### PR DESCRIPTION
## Summary
- Fix public /documents page to use doc.slug instead of doc.data.slug
- This makes uploaded documents show on the public page

## Problem
User uploaded 4 documents (bylaws, covenants, proxy-form, arb-request-form) successfully:
- R2 uploads: ✅ successful
- Database updates: ✅ file_key set correctly
- But public /documents page still showed old static files

## Root Cause
The code was using `doc.data.slug` (from frontmatter) which was returning `null`, instead of `doc.slug` (auto-generated from filename) which has the correct values.

Since `doc.data.slug` was `null`, the override lookup `overrideBySlug[null]` never matched, so it always used the old `doc.data.fileUrl` static files.

## Solution
Changed line 91 from:
```typescript
const slug = doc.data.slug;
```
To:
```typescript
const slug = doc.slug; // Use auto-generated slug from filename
```

The filenames already match database slugs perfectly:
- arb-request-form.md → arb-request-form
- bylaws.md → bylaws  
- covenants.md → covenants
- proxy-form.md → proxy-form

So using the auto-generated slug makes the override matching work correctly.

## Test plan
- [x] Deploy to production
- [ ] Visit /documents page
- [ ] Click download on any of the 4 managed documents
- [ ] Should download from R2 via /api/public-doc-file instead of static /docs/ files

🤖 Generated with [Claude Code](https://claude.com/claude-code)