### PR TITLE
feat: Add cache busting to public document downloads

### DIFF
--- a/src/pages/documents.astro
+++ b/src/pages/documents.astro
@@ -32,7 +32,7 @@ console.log('[DOCUMENTS-PAGE] Public overrides from DB:', publicOverrides.map(r 
 const overrideBySlug = Object.fromEntries(
   publicOverrides
     .filter((r) => r.file_key)
-    .map((r) => [r.slug, { slug: r.slug, file_key: r.file_key, content_type: r.content_type }])
+    .map((r) => [r.slug, { slug: r.slug, file_key: r.file_key, content_type: r.content_type, updated_at: r.updated_at }])
 );
 console.log('[DOCUMENTS-PAGE] Override map keys:', Object.keys(overrideBySlug));
 
@@ -94,7 +94,9 @@ const keyRules = [
             {docs.map((doc) => {
               const slug = doc.slug; // Use auto-generated slug from filename, not doc.data.slug
               const override = slug ? overrideBySlug[slug] : null;
-              const linkUrl = override?.file_key ? `/api/public-doc-file?slug=${encodeURIComponent(slug!)}` : doc.data.fileUrl;
+              // Add cache buster using updated_at timestamp to force new downloads when file is re-uploaded
+              const cacheBuster = override?.updated_at ? `&v=${encodeURIComponent(override.updated_at)}` : '';
+              const linkUrl = override?.file_key ? `/api/public-doc-file?slug=${encodeURIComponent(slug!)}${cacheBuster}` : doc.data.fileUrl;
               const isPdf = linkUrl.toLowerCase().includes('.pdf') || (override?.content_type?.toLowerCase().includes('pdf'));
               console.log('[DOCUMENTS-PAGE] Rendering doc:', { slug, hasOverride: !!override, linkUrl });
               return (


### PR DESCRIPTION
## Summary
- Adds cache-busting version parameter to public document download URLs
- Ensures users get the latest version immediately after upload

## Problem
User uploaded v1.1 of a document but was still getting v1.0 when downloading from the public /documents page. This was because the `/api/public-doc-file` endpoint has a 1-hour cache:
```typescript
headers.set('Cache-Control', 'public, max-age=3600');
```

Once downloaded, the file was cached in browsers and CDN for 1 hour. Uploading a new version within that hour still served the old cached version.

## Solution
Include the `updated_at` timestamp from the database in the download URL as a version parameter:
- Before: `/api/public-doc-file?slug=bylaws`  
- After: `/api/public-doc-file?slug=bylaws&v=2026-02-16+14:40:39`

When a new version is uploaded, `updated_at` changes, which creates a new URL, which bypasses all caches.

## Changes
1. Include `updated_at` in the `overrideBySlug` map
2. Add cache buster parameter to the link URL when override exists
3. Browser sees it as a different URL → fresh download

## Test plan
- [x] Deploy to production
- [ ] User uploads a new version of a document
- [ ] Immediately download from /documents page
- [ ] Should get the new version, not the cached old version

🤖 Generated with [Claude Code](https://claude.com/claude-code)