### PR TITLE
feat: Link public documents to compliance tracking via references

### DIFF
--- a/src/pages/portal/compliance.astro
+++ b/src/pages/portal/compliance.astro
@@ -10,6 +10,7 @@ import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listComplianceRequirements, getCurrentComplianceDocument, type ComplianceRequirement, type ComplianceDocument } from '../../lib/compliance-db';
+import { listPublicDocuments } from '../../lib/public-documents-db';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -25,21 +26,47 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
 // Fetch all requirements
 const allRequirements = await listComplianceRequirements(db);
 
+// Fetch public documents to check if they satisfy any requirements
+const publicDocs = await listPublicDocuments(db);
+const publicDocsBySlug = Object.fromEntries(publicDocs.map(d => [d.slug, d]));
+
+// Map public doc slugs to compliance requirement IDs
+const publicDocToRequirement: Record<string, string> = {
+  'bylaws': 'HOA-02',
+  'covenants': 'HOA-03',
+};
+
 // For each requirement, get current document if exists
+// Check both compliance_documents table AND public_documents table
 interface RequirementWithDoc {
   requirement: ComplianceRequirement;
   document: ComplianceDocument | null;
+  publicDoc?: typeof publicDocs[0]; // Reference to public doc if applicable
 }
 
 const requirementsWithDocs: RequirementWithDoc[] = await Promise.all(
   allRequirements.map(async (req) => {
+    // First check compliance_documents table
     const doc = await getCurrentComplianceDocument(db, req.id);
-    return { requirement: req, document: doc };
+
+    // If no compliance doc, check if there's a public doc that satisfies this requirement
+    let publicDoc = undefined;
+    if (!doc) {
+      const publicSlug = Object.keys(publicDocToRequirement).find(
+        slug => publicDocToRequirement[slug] === req.id
+      );
+      if (publicSlug && publicDocsBySlug[publicSlug]?.file_key) {
+        publicDoc = publicDocsBySlug[publicSlug];
+      }
+    }
+
+    return { requirement: req, document: doc, publicDoc };
   })
 );
 
 // Members see all documents (public + members-only)
-const availableRequirements = requirementsWithDocs.filter(({ document }) => !!document);
+// Include requirements that have either a compliance doc OR a public doc
+const availableRequirements = requirementsWithDocs.filter(({ document, publicDoc }) => !!document || !!publicDoc);
 
 // Group by category
 const categories = [
@@ -66,8 +93,12 @@ function formatDate(s: string | null): string {
 }
 
 const totalDocs = availableRequirements.length;
-const publicDocs = availableRequirements.filter(({ document }) => document?.visibility === 'public').length;
-const memberDocs = availableRequirements.filter(({ document }) => document?.visibility === 'members').length;
+const publicDocsCount = availableRequirements.filter(({ document, publicDoc }) =>
+  (document?.visibility === 'public') || !!publicDoc
+).length;
+const memberDocsCount = availableRequirements.filter(({ document, publicDoc }) =>
+  (document?.visibility === 'members') && !publicDoc
+).length;
 const totalRequirements = allRequirements.length;
 const compliancePercent = totalRequirements > 0 ? Math.round((totalDocs / totalRequirements) * 100) : 0;
 ---
@@ -110,11 +141,11 @@ const compliancePercent = totalRequirements > 0 ? Math.round((totalDocs / totalR
           <div class="text-base text-gray-600">Available</div>
         </div>
         <div class="p-4 rounded-xl bg-white shadow-sm border border-gray-100">
-          <div class="text-3xl font-bold text-gray-700 mb-1">{publicDocs}</div>
+          <div class="text-3xl font-bold text-gray-700 mb-1">{publicDocsCount}</div>
           <div class="text-base text-gray-600">Public</div>
         </div>
         <div class="p-4 rounded-xl bg-white shadow-sm border border-gray-100">
-          <div class="text-3xl font-bold text-blue-600 mb-1">{memberDocs}</div>
+          <div class="text-3xl font-bold text-blue-600 mb-1">{memberDocsCount}</div>
           <div class="text-base text-gray-600">Members-Only</div>
         </div>
       </div>
@@ -129,12 +160,22 @@ const compliancePercent = totalRequirements > 0 ? Math.round((totalDocs / totalR
                 {category.label}
               </h2>
               <div class="space-y-3">
-                {category.items.map(({ requirement, document }) => (
+                {category.items.map(({ requirement, document, publicDoc }) => {
+                  // Use publicDoc if no compliance doc exists
+                  const effectiveDoc = document || publicDoc;
+                  const isFromPublicDocs = !document && !!publicDoc;
+
+                  return (
                   <div class="p-4 rounded-xl border border-gray-200 hover:border-clr-green/30 hover:shadow-sm transition-all">
                     <div class="flex items-start justify-between gap-4 flex-wrap">
                       <div class="flex-1 min-w-0">
                         <div class="flex items-center gap-2 mb-1 flex-wrap">
                           <h3 class="font-medium text-base text-gray-900">{requirement.title}</h3>
+                          {(isFromPublicDocs || document?.visibility === 'public') && (
+                            <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+                              Public
+                            </span>
+                          )}
                           {document?.visibility === 'members' && (
                             <span class="px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
                               Members Only
@@ -147,19 +188,22 @@ const compliancePercent = totalRequirements > 0 ? Math.round((totalDocs / totalR
                           )}
                         </div>
                         <p class="text-base text-gray-600 mb-2">{requirement.statute_ref}</p>
-                        {document && (
+                        {effectiveDoc && (
                           <div class="flex items-center gap-4 text-base text-gray-500 flex-wrap">
-                            <span>📄 {document.title}</span>
-                            {document.document_date && (
+                            <span>📄 {isFromPublicDocs ? publicDoc.title : document!.title}</span>
+                            {document?.document_date && (
                               <span>📅 {formatDate(document.document_date)}</span>
                             )}
-                            <span class="text-xs">Updated {formatDate(document.uploaded_at)}</span>
+                            <span class="text-xs">Updated {formatDate(isFromPublicDocs ? publicDoc.updated_at : document!.uploaded_at)}</span>
                           </div>
                         )}
                       </div>
-                      {document?.file_key && (
+                      {effectiveDoc && (
                         <a
-                          href={`/api/compliance/file/${document.file_key}`}
+                          href={isFromPublicDocs
+                            ? `/api/public-doc-file?slug=${publicDoc.slug}&v=${encodeURIComponent(publicDoc.updated_at || '')}`
+                            : `/api/compliance/file/${document!.file_key}`
+                          }
                           class="px-4 py-2 bg-clr-green text-white rounded-lg font-medium hover:brightness-110 text-base whitespace-nowrap"
                           target="_blank"
                           rel="noopener noreferrer"
@@ -169,7 +213,8 @@ const compliancePercent = totalRequirements > 0 ? Math.round((totalDocs / totalR
                       )}
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             </section>
           ))}


### PR DESCRIPTION
## Summary
- Link public documents (bylaws, covenants) to compliance tracking without duplicating data
- Query both `compliance_documents` and `public_documents` tables
- Map public doc slugs to compliance requirement IDs
- Show public docs as satisfying statutory requirements
- Display "Public" badge for documents from public_documents table
- Include public docs in compliance percentage calculation

## Changes
- Modified `/src/pages/portal/compliance.astro` to reference public documents
- Added mapping: bylaws → HOA-02, covenants → HOA-03
- Used cache-busted links to public doc API

## Test plan
- [x] Verify compliance page shows uploaded public documents
- [x] Check compliance percentage updates when public docs exist
- [x] Confirm download links use cache-busted public doc API

🤖 Generated with [Claude Code](https://claude.com/claude-code)