### PR TITLE
fix: Add /api/vendors to elevated API middleware list

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,6 +47,7 @@ const ELEVATED_API_PREFIXES = [
   '/api/arb-notes',
   '/api/arb-deadline',
   '/api/arb-export',
+  '/api/vendors',
 ];
 
 /** Suspicious path patterns commonly used in credential scanning attacks. Block these early. */


### PR DESCRIPTION
## Summary
- Add `/api/vendors` to the `ELEVATED_API_PREFIXES` list in middleware
- Ensures middleware validates session and sets `Astro.locals.user` and `Astro.locals.session` for vendor API routes
- Required for PIM-based authorization to work correctly

## Root Cause
The vendor CSV upload endpoint expected `Astro.locals.user` and `Astro.locals.session` to be set by the middleware, but the middleware only processes API routes that match specific prefixes. `/api/vendors` was not in the list, so the middleware skipped session validation for vendor routes, leaving `Astro.locals.user` and `Astro.locals.session` undefined.

## Fix
Added `/api/vendors` to `ELEVATED_API_PREFIXES` array so middleware will:
1. Validate the session cookie
2. Check PIM elevation status
3. Set `Astro.locals.user` and `Astro.locals.session`
4. Return 403 if user lacks elevated role or active elevation

## Test plan
- [x] Elevate to board role via PIM
- [x] Upload vendor CSV file
- [x] Verify `Astro.locals.user` and `Astro.locals.session` are set
- [x] Verify upload succeeds without 401 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)