### PR TITLE
fix: Remove stray 'unt}' text from all board pages

### DIFF
--- a/src/pages/board/assessments.astro
+++ b/src/pages/board/assessments.astro
@@ -91,7 +91,6 @@ function formatCurrency(n: number): string {
   >
     <BoardNav currentPath="/board/assessments" />
 
-unt}
 <div id="csrf-holder" class="hidden" data-csrf={escapeHtml(session.csrfToken ?? '')} aria-hidden="true"></div>
   <div id="assessments-message" class="hidden mb-4 p-4 rounded-xl border" role="status" aria-live="polite" aria-atomic="true"></div>
 

--- a/src/pages/board/audit-logs.astro
+++ b/src/pages/board/audit-logs.astro
@@ -119,7 +119,6 @@ function formatDate(s: string | null): string {
   >
     <AdminNav currentPath="/board/audit-logs" />
 
-unt}
 <p class="text-gray-600 mb-4">
         Full audit logs for transparency: PIM elevated access requests, directory (contact reveals, who added/updated owners), assessment payments recorded, vendor list changes and vendor submission approvals/rejections, member document uploads, special assessments, preapproval library, feedback docs, meetings, and ARB status changes. <strong>Revealed contact information (phone numbers and emails that were viewed) is redacted for privacy, but the identity of who performed each action is shown for accountability.</strong>
   </p>

--- a/src/pages/board/compliance.astro
+++ b/src/pages/board/compliance.astro
@@ -117,7 +117,6 @@ function getCategoryLabel(category: string): string {
   >
     <AdminNav currentPath="/board/compliance" />
 
-unt}
 <!-- Action Required Alert (if any PARTIAL items) -->
   {actionRequired.length > 0 && (
     <div class="mb-6 p-6 rounded-2xl bg-amber-50 border-2 border-amber-300 shadow-md">

--- a/src/pages/board/feedback.astro
+++ b/src/pages/board/feedback.astro
@@ -83,7 +83,6 @@ function formatDate(s: string | null): string {
   >
     <BoardNav currentPath="/board/feedback" />
 
-unt}
 <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
         <h2 class="text-3xl font-heading font-bold text-clr-green">Feedback documents</h2>
         <button type="button" id="btn-new-feedback" class="inline-flex items-center gap-2 bg-clr-green hover:brightness-110 text-white px-5 py-2.5 rounded-xl font-semibold text-base">

--- a/src/pages/board/library.astro
+++ b/src/pages/board/library.astro
@@ -61,7 +61,6 @@ const categories = db ? await listPreapprovalCategories(db) : [];
   >
     <BoardNav currentPath="/board/library" />
 
-unt}
 <h2 class="text-3xl font-heading font-bold text-clr-green mb-6">Add pre-approval item</h2>
       <form id="library-form" class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-8 space-y-4">
         <input type="hidden" name="id" id="form-id" value="" />

--- a/src/pages/board/maintenance.astro
+++ b/src/pages/board/maintenance.astro
@@ -78,7 +78,6 @@ function categoryLabel(cat: string): string {
   >
     <AdminNav currentPath="/board/maintenance" />
 
-unt}
 <h2 class="text-3xl font-heading font-bold text-clr-green mb-4">Maintenance requests</h2>
       <div class="flex flex-wrap gap-2 mb-6">
         <a

--- a/src/pages/board/meetings.astro
+++ b/src/pages/board/meetings.astro
@@ -78,7 +78,6 @@ function formatDateTime(dt: string): string {
   >
     <BoardNav currentPath="/board/meetings" />
 
-unt}
 <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
         <h2 class="text-3xl font-heading font-bold text-clr-green">Meetings</h2>
         <button

--- a/src/pages/board/member-documents.astro
+++ b/src/pages/board/member-documents.astro
@@ -80,7 +80,6 @@ const docsByCategory = MEMBER_DOC_CATEGORIES.map((cat) => ({
   >
     <AdminNav currentPath="/board/member-documents" />
 
-unt}
 <div class="mb-8 p-4 rounded-xl bg-blue-50 border border-blue-200 text-blue-900" role="alert">
     <p class="font-semibold">Members only.</p>
     <p class="text-base mt-1">These files are visible only to logged-in members on the <a href="/portal/documents" class="underline font-medium" target="_blank" rel="noopener noreferrer">Documents page <span class="text-blue-700/80">(opens in new tab)</span></a>. Use for redacted minutes, budgets, and other member-only content.</p>

--- a/src/pages/board/news.astro
+++ b/src/pages/board/news.astro
@@ -73,7 +73,6 @@ function formatDate(s: string | null): string {
   >
     <AdminNav currentPath="/board/news" />
 
-unt}
 <div id="csrf-holder" class="hidden" data-csrf={escapeHtml(session.csrfToken ?? '')} aria-hidden="true"></div>
   <div class="mb-6">
     <h2 class="text-3xl font-heading font-bold text-clr-green mb-2">Add news</h2>

--- a/src/pages/board/vendors.astro
+++ b/src/pages/board/vendors.astro
@@ -86,7 +86,6 @@ function parseFiles(filesJson: string | null): { name: string; key: string }[] {
   >
     <AdminNav currentPath="/board/vendors" />
 
-unt}
 <div id="csrf-holder" class="hidden" data-csrf={escapeHtml(session.csrfToken ?? '')} aria-hidden="true"></div>
   <div id="vendors-message" class="hidden mb-4 p-4 rounded-xl border" role="status" aria-live="polite" aria-atomic="true"></div>
       {pendingSubmissions.length > 0 && (


### PR DESCRIPTION
## Summary
- Removed corrupted `unt}` lines appearing on 10 board pages
- This stray text was visible to users immediately on page load

## Affected Pages
- `/board/assessments`
- `/board/audit-logs`
- `/board/compliance`
- `/board/feedback`
- `/board/library`
- `/board/maintenance`
- `/board/meetings`
- `/board/member-documents`
- `/board/news`
- `/board/vendors`

## Root Cause
Corrupted text from a previous template or copy-paste operation left standalone `unt}` lines in the HTML output of these pages.

## Fix
Used sed to remove all lines containing only whitespace and `unt}` from the affected files.

## Test plan
- [x] Verified all `unt}` occurrences removed from board pages
- [x] Checked portal pages (none found)
- [x] Pages now render cleanly without stray text

🤖 Generated with [Claude Code](https://claude.com/claude-code)