### PR TITLE
fix: Add directory export to elevated API middleware and use PIM session

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,6 +48,7 @@ const ELEVATED_API_PREFIXES = [
   '/api/arb-deadline',
   '/api/arb-export',
   '/api/vendors',
+  '/api/directory-export',
 ];
 
 /** Suspicious path patterns commonly used in credential scanning attacks. Block these early. */

--- a/src/pages/api/directory-export.astro
+++ b/src/pages/api/directory-export.astro
@@ -5,25 +5,34 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, isElevatedRole, getEffectiveRole } from '../../lib/auth';
+import { getEffectiveRole, isElevatedRole } from '../../lib/auth';
 import { listOwners, getPhonesArray, insertDirectoryExportLog } from '../../lib/directory-db';
 import { escapeCsv } from '../../lib/csv-utils';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+console.log('[DIRECTORY-EXPORT] Auth check:', {
+  hasUser: !!user,
+  hasSession: !!session,
+  sessionAssumedRole: (session as any)?.assumed_role,
+});
+
+if (!session || !user) {
+  console.log('[DIRECTORY-EXPORT] Unauthorized - missing session or user');
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
   });
 }
 
-if (!isElevatedRole(getEffectiveRole(session))) {
+const effectiveRole = getEffectiveRole(session as any);
+console.log('[DIRECTORY-EXPORT] Effective role:', effectiveRole);
+
+if (!isElevatedRole(effectiveRole)) {
+  console.log('[DIRECTORY-EXPORT] Forbidden - not elevated role');
   return new Response(JSON.stringify({ error: 'Forbidden' }), {
     status: 403,
     headers: { 'Content-Type': 'application/json' },
@@ -52,7 +61,7 @@ const csv = header + rows.join('\n');
 
 // Log once for this export (not per user)
 const clientIp = Astro.clientAddress || Astro.request.headers.get('cf-connecting-ip') || null;
-await insertDirectoryExportLog(db, session.email, getEffectiveRole(session), clientIp);
+await insertDirectoryExportLog(db, user.email, effectiveRole, clientIp);
 
 const filename = `directory-export-${new Date().toISOString().slice(0, 10)}.csv`;
 return new Response(csv, {


### PR DESCRIPTION
## Summary
- Fix directory CSV export failure when using assumed board role
- Add `/api/directory-export` to middleware's `ELEVATED_API_PREFIXES`
- Change endpoint to use `Astro.locals.user` and `Astro.locals.session`
- Ensures PIM attributes are available for authorization

## Root Cause
Same issue as vendor CSV upload (#203, #204):
1. Directory export endpoint used `getSessionFromCookie` directly
2. Middleware didn't process `/api/directory-export` routes
3. Session didn't have PIM attributes (assumed_role, elevated_until)
4. `getEffectiveRole()` couldn't see assumed board role
5. Export failed with 403 Forbidden

## Fix
- Added `/api/directory-export` to middleware list
- Updated endpoint to use middleware-provided session
- Use `user.email` and `effectiveRole` (already computed)
- Added debug logging

## Test plan
- [x] Elevate to board role via PIM
- [x] Export directory CSV
- [x] Verify export succeeds without 403 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)