### PR TITLE
fix: Add /api/members to elevated API prefixes in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,6 +38,7 @@ function isProfileComplete(
 const ELEVATED_API_PREFIXES = [
   '/api/admin',
   '/api/board',
+  '/api/members',
   '/api/owners',
   '/api/meetings',
   '/api/maintenance-update',


### PR DESCRIPTION
## Problem
The unified members page was returning a 401 Unauthorized error when trying to load member data:
```
GET https://www.clrhoa.com/api/members 401 (Unauthorized)
```

## Root Cause
The `/api/members` endpoint requires `locals.user` and `locals.session` to be set by middleware for authentication. However, `/api/members` was not included in the `ELEVATED_API_PREFIXES` array in the middleware, so these values were never set.

## Solution
Added `/api/members` to the `ELEVATED_API_PREFIXES` array in `src/middleware.ts`.

Now the middleware:
- ✅ Validates the session for `/api/members` requests
- ✅ Checks for elevated role (board, admin, arb_board)
- ✅ Sets `locals.user` and `locals.session` for the API handler
- ✅ Returns 403 if user doesn't have elevated role
- ✅ Returns 403 if PIM elevation has expired

## Testing
After this fix, the members page should:
1. Load successfully without 401 errors
2. Display the member list
3. Allow CSV upload
4. Allow adding/updating/deleting members

## Impact
- One-line change to middleware configuration
- Fixes authentication for all `/api/members/*` endpoints
- No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)