### PR TITLE
debug: Add CSRF verification logging for CSV upload

### DIFF
--- a/src/pages/api/members/upload-csv.ts
+++ b/src/pages/api/members/upload-csv.ts
@@ -131,12 +131,21 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   // 4. CSRF verification
   const csrf = (formData.get('csrf_token') ?? formData.get('csrfToken'))?.toString() ?? '';
+  console.log('[CSV-UPLOAD] CSRF Debug:', {
+    csrfToken: csrf?.substring(0, 20) + '...',
+    hasSession: !!session,
+    sessionKeys: session ? Object.keys(session) : [],
+  });
+
   if (!verifyCsrfToken(session as any, csrf)) {
+    console.log('[CSV-UPLOAD] CSRF verification failed');
     return new Response(JSON.stringify({ error: 'Invalid security token.' }), {
       status: 403,
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+  console.log('[CSV-UPLOAD] CSRF verification passed');
 
   // 5. Get CSV file
   const file = formData.get('file') ?? formData.get('csv');


### PR DESCRIPTION
## Problem
CSV upload returns 403 "Invalid security token"

## Debug Approach
Add detailed logging to understand why CSRF verification is failing:

```javascript
console.log('[CSV-UPLOAD] CSRF Debug:', {
  csrfToken: csrf?.substring(0, 20) + '...',
  hasSession: !!session,
  sessionKeys: session ? Object.keys(session) : [],
});
```

## What This Will Show
- Whether CSRF token is being sent
- What the session object looks like from middleware
- If session has the expected structure for CSRF verification

## Next Steps
After deploying this:
1. Try CSV upload again
2. Check Cloudflare logs for debug output
3. Identify why `verifyCsrfToken()` is returning false
4. Fix the root cause

## Suspected Issues
- Session structure from middleware might not match what `verifyCsrfToken` expects
- CSRF token might have been generated before PIM elevation
- Session might be missing required fields for CSRF verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)