### PR TITLE
fix: Add CSRF token to session object in middleware

### DIFF
--- a/src/lib/auth/middleware.ts
+++ b/src/lib/auth/middleware.ts
@@ -19,6 +19,7 @@ import type { APIContext } from 'astro';
 import { createLucia } from '../lucia';
 import type { Session, User } from 'lucia';
 import { getUserRole } from '../../types/auth';
+import crypto from 'node:crypto';
 
 export const SESSION_COOKIE_NAME = 'clrhoa_session';
 
@@ -70,12 +71,19 @@ export async function validateSession(
     // Manually fetch custom session attributes (Lucia D1 adapter doesn't include them)
     // This includes elevated_until, assumed_role, assumed_at, assumed_until for PIM
     // Also add the user's base role so getEffectiveRole() can access it
+    // Also add CSRF token for form submissions
     if (result.session && dbSession) {
       (result.session as any).role = result.user.role;
       (result.session as any).elevated_until = dbSession.elevated_until;
       (result.session as any).assumed_role = dbSession.assumed_role;
       (result.session as any).assumed_at = dbSession.assumed_at;
       (result.session as any).assumed_until = dbSession.assumed_until;
+
+      // Generate CSRF token if not present in DB session
+      // Use the session ID as a stable basis for CSRF token to avoid regeneration on every request
+      const csrfToken = dbSession.csrf_token || crypto.createHash('sha256').update(result.session.id + 'csrf-salt').digest('hex');
+      (result.session as any).csrfToken = csrfToken;
+
       console.log('[VALIDATE DEBUG] Added PIM attributes - role:', result.user.role, 'elevated_until:', dbSession.elevated_until, 'assumed_role:', dbSession.assumed_role);
     }
 


### PR DESCRIPTION
## Problem
CSV upload fails with 403 "Invalid security token"

Debug logs showed:
```json
"sessionKeys": ["id", "userId", "fresh", "expiresAt", "role", ...]
// csrfToken is MISSING!
```

## Root Cause
The `verifyCsrfToken()` function expects `session.csrfToken` to exist, but the Lucia session object doesn't include it by default. The middleware adds PIM attributes but was missing the CSRF token.

## Solution
Generate and add `csrfToken` to session object after validation:

```typescript
// Generate CSRF token from session ID (stable per session)
const csrfToken = crypto
  .createHash('sha256')
  .update(result.session.id + 'csrf-salt')
  .digest('hex');
(result.session as any).csrfToken = csrfToken;
```

## Why This Works
- **Stable**: CSRF token derived from session ID, so it's consistent across requests
- **Secure**: Uses cryptographic hash of session ID + salt
- **Compatible**: Works with existing `verifyCsrfToken()` function
- **No DB changes**: Generates token on-the-fly from session data

## Changes
- Import `crypto` module
- Generate CSRF token from session ID after validation
- Add `csrfToken` field to session object alongside PIM attributes

## Testing
After this fix:
1. Page will have valid CSRF token: `session.csrfToken` exists
2. Form will send the token
3. API will verify successfully
4. CSV upload should work!

🤖 Generated with [Claude Code](https://claude.com/claude-code)