### PR TITLE
debug: Add detailed CSRF token comparison logging

### DIFF
--- a/src/pages/api/members/upload-csv.ts
+++ b/src/pages/api/members/upload-csv.ts
@@ -132,13 +132,17 @@ export const POST: APIRoute = async ({ request, locals }) => {
   // 4. CSRF verification
   const csrf = (formData.get('csrf_token') ?? formData.get('csrfToken'))?.toString() ?? '';
   console.log('[CSV-UPLOAD] CSRF Debug:', {
-    csrfToken: csrf?.substring(0, 20) + '...',
+    formToken: csrf?.substring(0, 20) + '...' || '(empty)',
+    formTokenLength: csrf?.length || 0,
+    sessionToken: (session as any)?.csrfToken?.substring(0, 20) + '...' || '(empty)',
+    sessionTokenLength: (session as any)?.csrfToken?.length || 0,
+    tokensMatch: csrf === (session as any)?.csrfToken,
     hasSession: !!session,
     sessionKeys: session ? Object.keys(session) : [],
   });
 
   if (!verifyCsrfToken(session as any, csrf)) {
-    console.log('[CSV-UPLOAD] CSRF verification failed');
+    console.log('[CSV-UPLOAD] CSRF verification failed - tokens do not match');
     return new Response(JSON.stringify({ error: 'Invalid security token.' }), {
       status: 403,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
Add enhanced debug logging to CSV upload endpoint to diagnose CSRF token verification failure.

## Changes
- Add detailed token comparison logging showing:
  - Form token (first 20 chars + length)
  - Session token (first 20 chars + length)
  - Whether tokens match
  - Session keys available

## Purpose
This will help us see exactly why CSRF verification is failing despite the token now being present in the session.

## Test Plan
1. Deploy this change
2. Attempt CSV upload
3. Check logs to see token comparison details

🤖 Generated with [Claude Code](https://claude.com/claude-code)