### PR TITLE
debug: Add session validation debug endpoint

### DIFF
--- a/src/pages/api/admin/debug-session.astro
+++ b/src/pages/api/admin/debug-session.astro
@@ -1,0 +1,138 @@
+---
+/**
+ * POST /api/admin/debug-session — Debug endpoint to test session validation
+ *
+ * Tests session validation with fingerprinting and shows detailed diagnostic info.
+ * Admin only. Remove this endpoint after debugging is complete.
+ */
+export const prerender = false;
+
+import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, getEffectiveRole } from '../../../lib/auth';
+import { isElevatedRole } from '../../../lib/auth';
+
+const runtime = Astro.locals.runtime;
+const env = runtime?.env;
+
+if (Astro.request.method !== 'POST') {
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+    status: 405,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Get request details
+const userAgent = Astro.request.headers.get('user-agent') ?? null;
+const ipAddress = Astro.request.headers.get('cf-connecting-ip') ??
+  Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
+const cookieHeader = Astro.request.headers.get('cookie') ?? undefined;
+const origin = Astro.request.headers.get('origin');
+const referer = Astro.request.headers.get('referer');
+
+// Diagnostic info object
+const diagnostic: any = {
+  timestamp: new Date().toISOString(),
+  headers: {
+    userAgent,
+    ipAddress,
+    origin,
+    referer,
+    hasCookie: !!cookieHeader,
+  },
+  tests: {},
+};
+
+// Test 1: Origin verification
+diagnostic.tests.originVerification = {
+  passed: verifyOrigin(origin, referer, Astro.url.origin),
+  expectedOrigin: Astro.url.origin,
+  actualOrigin: origin,
+  actualReferer: referer,
+};
+
+if (!diagnostic.tests.originVerification.passed) {
+  return new Response(JSON.stringify({
+    error: 'Origin verification failed',
+    diagnostic,
+  }), {
+    status: 403,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Test 2: Session validation without fingerprinting
+const sessionNoFingerprint = await getSessionFromCookie(
+  cookieHeader,
+  env?.SESSION_SECRET
+);
+
+diagnostic.tests.sessionWithoutFingerprint = {
+  valid: !!sessionNoFingerprint,
+  email: sessionNoFingerprint?.email,
+  role: sessionNoFingerprint?.role,
+};
+
+// Test 3: Session validation WITH fingerprinting (correct way)
+const sessionWithFingerprint = await getSessionFromCookie(
+  cookieHeader,
+  env?.SESSION_SECRET,
+  userAgent,
+  ipAddress
+);
+
+diagnostic.tests.sessionWithFingerprint = {
+  valid: !!sessionWithFingerprint,
+  email: sessionWithFingerprint?.email,
+  role: sessionWithFingerprint?.role,
+  elevated_until: sessionWithFingerprint?.elevated_until,
+  csrfToken: sessionWithFingerprint?.csrfToken?.substring(0, 10) + '...',
+};
+
+// Test 4: Effective role check
+if (sessionWithFingerprint) {
+  const effectiveRole = getEffectiveRole(sessionWithFingerprint);
+  diagnostic.tests.effectiveRole = {
+    role: effectiveRole,
+    isElevated: isElevatedRole(effectiveRole),
+  };
+}
+
+// Test 5: CSRF token validation
+let body: { csrf_token?: string; csrfToken?: string };
+try {
+  body = await Astro.request.json();
+} catch {
+  body = {};
+}
+
+diagnostic.tests.csrfValidation = {
+  tokenProvided: !!(body.csrf_token ?? body.csrfToken),
+  tokenValue: body.csrf_token ?? body.csrfToken,
+  sessionToken: sessionWithFingerprint?.csrfToken?.substring(0, 10) + '...',
+  valid: sessionWithFingerprint ? verifyCsrfToken(sessionWithFingerprint, body.csrf_token ?? body.csrfToken) : false,
+};
+
+// Final result
+const allTestsPassed =
+  diagnostic.tests.originVerification.passed &&
+  diagnostic.tests.sessionWithFingerprint.valid &&
+  diagnostic.tests.effectiveRole?.isElevated &&
+  diagnostic.tests.csrfValidation.valid;
+
+return new Response(JSON.stringify({
+  success: allTestsPassed,
+  diagnostic,
+  summary: {
+    originCheck: diagnostic.tests.originVerification.passed ? '✅ PASS' : '❌ FAIL',
+    sessionNoFingerprint: diagnostic.tests.sessionWithoutFingerprint.valid ? '✅ Valid' : '❌ Invalid',
+    sessionWithFingerprint: diagnostic.tests.sessionWithFingerprint.valid ? '✅ Valid' : '❌ Invalid',
+    effectiveRole: diagnostic.tests.effectiveRole?.isElevated ? '✅ Elevated' : '❌ Not Elevated',
+    csrfValidation: diagnostic.tests.csrfValidation.valid ? '✅ Valid' : '❌ Invalid',
+  },
+  recommendation: allTestsPassed ?
+    'All tests passed! Session validation is working correctly.' :
+    'Some tests failed. Check diagnostic details above.',
+}), {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+});
+---

--- a/src/pages/portal/admin/debug-session.astro
+++ b/src/pages/portal/admin/debug-session.astro
@@ -1,0 +1,173 @@
+---
+/**
+ * Admin Debug Session Test Page
+ *
+ * Tests session validation to diagnose authentication issues.
+ * Remove this page after debugging is complete.
+ */
+import PortalPage from '../../../components/PortalPage.astro';
+import { getEffectiveRole } from '../../../lib/auth';
+import type { ExtendedSession } from '../../../types/auth';
+
+const user = Astro.locals.user;
+const session = Astro.locals.session;
+
+// Admin role check
+const effectiveRole = getEffectiveRole(session as ExtendedSession | null);
+if (effectiveRole.toLowerCase() !== 'admin') {
+  return Astro.redirect('/portal/dashboard');
+}
+
+// Get CSRF token from session
+const csrfToken = (session as any)?.csrfToken || '';
+---
+
+<PortalPage
+  currentPath="/portal/admin/debug-session"
+  pageTitle="Debug Session"
+  userEmail={user?.email || ''}
+  effectiveRole={effectiveRole}
+>
+  <div class="max-w-4xl mx-auto">
+    <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+          </svg>
+        </div>
+        <div class="ml-3">
+          <p class="text-sm text-yellow-700">
+            <strong>Debug Endpoint:</strong> Remove this page and API endpoint after debugging is complete.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Session Debug Test</h1>
+
+    <div class="bg-white shadow rounded-lg p-6 mb-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Current Session Info</h2>
+      <dl class="grid grid-cols-1 gap-4">
+        <div>
+          <dt class="text-sm font-medium text-gray-500">Email</dt>
+          <dd class="mt-1 text-sm text-gray-900">{user?.email || 'Not available'}</dd>
+        </div>
+        <div>
+          <dt class="text-sm font-medium text-gray-500">Role</dt>
+          <dd class="mt-1 text-sm text-gray-900">{user?.role || 'Not available'}</dd>
+        </div>
+        <div>
+          <dt class="text-sm font-medium text-gray-500">CSRF Token (first 20 chars)</dt>
+          <dd class="mt-1 text-sm text-gray-900 font-mono">{csrfToken?.substring(0, 20) || 'Not available'}...</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="bg-white shadow rounded-lg p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Run Session Validation Test</h2>
+      <p class="text-sm text-gray-600 mb-4">
+        Click the button below to test session validation with the debug endpoint.
+        This will show detailed diagnostic information about authentication.
+      </p>
+
+      <button
+        id="testButton"
+        type="button"
+        class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+      >
+        Run Session Test
+      </button>
+
+      <div id="results" class="mt-6"></div>
+    </div>
+  </div>
+
+  <script define:vars={{ csrfToken }}>
+    const testButton = document.getElementById('testButton');
+    const resultsDiv = document.getElementById('results');
+
+    testButton?.addEventListener('click', async () => {
+      if (!testButton) return;
+
+      testButton.disabled = true;
+      testButton.textContent = 'Testing...';
+      resultsDiv.innerHTML = '<p class="text-gray-500">Running diagnostic tests...</p>';
+
+      try {
+        const response = await fetch('/api/admin/debug-session', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            csrf_token: csrfToken,
+          }),
+        });
+
+        const data = await response.json();
+
+        // Display results
+        const summaryHtml = `
+          <div class="border ${data.success ? 'border-green-300 bg-green-50' : 'border-red-300 bg-red-50'} rounded-lg p-4 mb-4">
+            <h3 class="font-semibold ${data.success ? 'text-green-800' : 'text-red-800'} mb-2">
+              ${data.success ? '✅ All Tests Passed' : '❌ Some Tests Failed'}
+            </h3>
+            <p class="text-sm ${data.success ? 'text-green-700' : 'text-red-700'}">
+              ${data.recommendation}
+            </p>
+          </div>
+        `;
+
+        const summaryTableHtml = `
+          <div class="mb-4">
+            <h4 class="font-medium text-gray-900 mb-2">Test Summary</h4>
+            <dl class="grid grid-cols-1 gap-2 text-sm">
+              <div class="flex justify-between">
+                <dt class="text-gray-600">Origin Check:</dt>
+                <dd class="font-mono">${data.summary.originCheck}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-gray-600">Session (no fingerprint):</dt>
+                <dd class="font-mono">${data.summary.sessionNoFingerprint}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-gray-600">Session (with fingerprint):</dt>
+                <dd class="font-mono">${data.summary.sessionWithFingerprint}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-gray-600">Effective Role:</dt>
+                <dd class="font-mono">${data.summary.effectiveRole}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-gray-600">CSRF Validation:</dt>
+                <dd class="font-mono">${data.summary.csrfValidation}</dd>
+              </div>
+            </dl>
+          </div>
+        `;
+
+        const detailsHtml = `
+          <details class="border border-gray-300 rounded-lg p-4">
+            <summary class="cursor-pointer font-medium text-gray-900">
+              View Detailed Diagnostic Info
+            </summary>
+            <pre class="mt-4 p-4 bg-gray-50 rounded text-xs overflow-auto">${JSON.stringify(data.diagnostic, null, 2)}</pre>
+          </details>
+        `;
+
+        resultsDiv.innerHTML = summaryHtml + summaryTableHtml + detailsHtml;
+      } catch (error) {
+        resultsDiv.innerHTML = `
+          <div class="border border-red-300 bg-red-50 rounded-lg p-4">
+            <h3 class="font-semibold text-red-800 mb-2">❌ Request Failed</h3>
+            <p class="text-sm text-red-700">${error instanceof Error ? error.message : String(error)}</p>
+          </div>
+        `;
+      } finally {
+        testButton.disabled = false;
+        testButton.textContent = 'Run Session Test';
+      }
+    });
+  </script>
+</PortalPage>


### PR DESCRIPTION
## Summary
- Creates debug API endpoint at `/api/admin/debug-session` that tests 5 validation steps
- Creates debug frontend page at `/portal/admin/debug-session` with button to run tests
- Displays detailed diagnostic information for troubleshooting test email 401 errors

## Purpose
These are **temporary debugging tools** to diagnose why the test email endpoint is returning 401 Unauthorized. Tests:
1. Origin verification
2. Session validation without fingerprinting
3. Session validation with fingerprinting (correct way)
4. Effective role check
5. CSRF token validation

## Next Steps
1. Navigate to `/portal/admin/debug-session` (admin only)
2. Click "Run Session Test" button
3. Review diagnostic output to identify the validation step that's failing
4. **Remove these files after troubleshooting is complete**

🤖 Generated with [Claude Code](https://claude.com/claude-code)