### PR TITLE
fix: Address lodash prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6152,9 +6152,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
   },
   "overrides": {
     "undici": ">=7.18.2",
+    "lodash": "4.17.23",
     "@astrojs/cloudflare": {
       "wrangler": "4.59.1"
     }


### PR DESCRIPTION
## Summary
- Adds npm override to force `lodash@4.17.23` across all transitive dependencies
- Resolves **GHSA-xxjr-mmjv-4gpg** (moderate severity, CVSS 6.5)
- Fixes prototype pollution vulnerability in `_.unset` and `_.omit` functions

## Details
**Vulnerability:** Lodash versions 4.0.0-4.17.22 had a prototype pollution vulnerability
**Affected Range:** `>=4.0.0 <=4.17.22`
**Fixed Version:** `4.17.23`
**Source:** Transitive dependency via `yaml-language-server@1.19.2`

## Verification
```bash
npm audit
# found 0 vulnerabilities

npm ls lodash
# lodash@4.17.23 overridden
```

## Test Plan
- [x] Run `npm install` - completes successfully
- [x] Run `npm audit` - shows 0 vulnerabilities  
- [x] Verify `npm ls lodash` shows version 4.17.23
- [x] Astro check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)