### PR TITLE
fix: Add CSRF token to PIM drop and extend buttons

### DIFF
--- a/src/components/PimElevationBanner.astro
+++ b/src/components/PimElevationBanner.astro
@@ -7,9 +7,10 @@ interface Props {
   elevatedUntil: number;
   role?: string;
   elevatedRole?: string;
+  csrfToken?: string;
 }
 
-const { elevatedUntil, elevatedRole } = Astro.props;
+const { elevatedUntil, elevatedRole, csrfToken = '' } = Astro.props;
 
 // Format role label for display
 const roleLabel = elevatedRole
@@ -19,7 +20,7 @@ const roleLabel = elevatedRole
   : 'elevated access';
 ---
 
-<div id="pim-elevation-banner" class="bg-amber-100 border-b border-amber-300 px-4 py-2 flex flex-wrap items-center justify-between gap-2" role="status" aria-live="polite" data-elevated-until={String(elevatedUntil)}>
+<div id="pim-elevation-banner" class="bg-amber-100 border-b border-amber-300 px-4 py-2 flex flex-wrap items-center justify-between gap-2" role="status" aria-live="polite" data-elevated-until={String(elevatedUntil)} data-csrf-token={csrfToken}>
   <span class="text-amber-900 text-sm font-medium">
     <span id="pim-elevation-label">Elevated as {roleLabel}</span>
     <span id="pim-elevation-timer" class="ml-2 font-mono">—</span>
@@ -42,6 +43,7 @@ const roleLabel = elevatedRole
     if (!timerEl || !bannerEl) return;
 
     let elevatedUntil = parseInt(bannerEl.getAttribute('data-elevated-until') || '0', 10);
+    const csrfToken = bannerEl.getAttribute('data-csrf-token') || '';
     const EXTENSION_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
 
     interface ExtendResponse {
@@ -90,7 +92,8 @@ const roleLabel = elevatedRole
       fetch('/api/pim/extend', {
         method: 'POST',
         credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csrf_token: csrfToken })
       })
         .then(function (r) {
           return r.json().then(function (data) {
@@ -134,7 +137,12 @@ const roleLabel = elevatedRole
     form?.addEventListener('submit', function (e) {
       e.preventDefault();
       clearInterval(interval);
-      fetch('/api/pim/drop', { method: 'POST', credentials: 'same-origin' })
+      fetch('/api/pim/drop', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csrf_token: csrfToken })
+      })
         .then(function (r) {
           if (r.ok) window.location.reload();
         })

--- a/src/components/PortalPage.astro
+++ b/src/components/PortalPage.astro
@@ -47,6 +47,7 @@ const {
 const session = Astro.locals.session;
 const sessionElevatedUntil = (session as any)?.elevated_until;
 const sessionAssumedRole = (session as any)?.assumed_role;
+const csrfToken = (session as any)?.csrfToken || '';
 
 // Use prop if provided, otherwise check session
 const actualElevatedUntil = elevatedUntil ?? sessionElevatedUntil ?? null;
@@ -85,7 +86,7 @@ const showPimBanner = actualElevatedUntil && actualElevatedUntil > now;
     <!-- Position below fixed header (h-16 = 64px) -->
     {showPimBanner && (
       <div class="mt-16">
-        <PimElevationBanner elevatedUntil={actualElevatedUntil!} role={effectiveRole} elevatedRole={elevatedRole} />
+        <PimElevationBanner elevatedUntil={actualElevatedUntil!} role={effectiveRole} elevatedRole={elevatedRole} csrfToken={csrfToken} />
       </div>
     )}
 

--- a/src/layouts/BoardLayout.astro
+++ b/src/layouts/BoardLayout.astro
@@ -35,12 +35,13 @@ const showPimBanner = typeof elevatedUntil === 'number' && elevatedUntil > Date.
 // Determine the elevated role to display
 // If assumed_role is set (for admin/arb_board), use that; otherwise use role
 const elevatedRole = session?.assumed_role || role;
+const csrfToken = session?.csrfToken || '';
 ---
 
 <PortalLayout title={`${title} | Board | Member Portal | Crooked Lake Reserve HOA`}>
   <ProtectedPage>
     <div class="min-h-screen portal-theme-bg font-body">
-      {showPimBanner && <PimElevationBanner elevatedUntil={elevatedUntil!} role={role} elevatedRole={elevatedRole} />}
+      {showPimBanner && <PimElevationBanner elevatedUntil={elevatedUntil!} role={role} elevatedRole={elevatedRole} csrfToken={csrfToken} />}
       <PortalNav currentPath={currentPath} draftCount={draftCount} role={role} staffRole={session?.role ?? role} />
       {showRoleBanner && <PortalElevatedRoleBanner role={role} session={session} />}
       {role === 'admin' ? <AdminNav currentPath={currentPath} /> : role === 'arb' ? <ArbNav currentPath={currentPath} /> : <BoardNav currentPath={currentPath} />}

--- a/src/pages/portal/dashboard.astro
+++ b/src/pages/portal/dashboard.astro
@@ -22,6 +22,7 @@ if (!session) return Astro.redirect('/auth/login');
 
 const { email, role, name } = session;
 const db = env?.DB;
+const csrfToken = session.csrfToken || '';
 
 // Use session name when set; otherwise fall back to directory (owner) name
 let displayName = name?.trim() || null;
@@ -131,7 +132,7 @@ const showActionNeededBanner = showActionFeedback || showActionMaintenance || sh
           <!-- PIM Elevation Banner -->
           {showPimBanner && (
             <div class="mb-6">
-              <PimElevationBanner elevatedUntil={session.elevated_until!} role={effectiveRole} elevatedRole={elevatedRole} />
+              <PimElevationBanner elevatedUntil={session.elevated_until!} role={effectiveRole} elevatedRole={elevatedRole} csrfToken={csrfToken} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
Fixes "Drop access" and "Extend access" buttons that stopped working after CSRF validation was enabled.

## Root Cause
PR #232 added CSRF validation to `/api/pim/drop` and `/api/pim/extend` endpoints, but the frontend fetch calls weren't updated to send the CSRF token.

## Changes
- Add `csrfToken` prop to `PimElevationBanner` component
- Pass `csrfToken` from session in `PortalPage`, `BoardLayout`, and `dashboard` 
- Update drop and extend fetch calls to send `csrf_token` in request body
- Store token in `data-csrf-token` attribute and read in client-side script

## Test Plan
1. Log in and elevate to admin/board/ARB role
2. Wait for PIM banner to appear
3. Click "Drop access" button - should work and redirect to dashboard
4. Elevate again, wait 45+ minutes for "Extend access" to appear
5. Click "Extend access" - should work and extend timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)