### PR TITLE
fix: Add CSRF token to change password form

### DIFF
--- a/src/pages/portal/profile/change-password.astro
+++ b/src/pages/portal/profile/change-password.astro
@@ -15,6 +15,9 @@ const session = Astro.locals.session;
 
 // Redirect if not authenticated
 if (!session) return Astro.redirect('/auth/login');
+
+// Get CSRF token from session
+const csrfToken = (session as any)?.csrfToken || '';
 ---
 
 <PortalLayout title="Change Password | Member Portal | Crooked Lake Reserve HOA">
@@ -48,7 +51,7 @@ if (!session) return Astro.redirect('/auth/login');
 
       <!-- Change Password Form -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <form id="change-password-form" class="space-y-6">
+        <form id="change-password-form" class="space-y-6" data-csrf-token={csrfToken}>
           <!-- Current Password -->
           <div>
             <label for="current-password" class="block text-sm font-medium text-gray-700 mb-2">
@@ -166,6 +169,7 @@ if (!session) return Astro.redirect('/auth/login');
   }
 
   const form = document.getElementById('change-password-form') as HTMLFormElement | null;
+  const csrfToken = form?.getAttribute('data-csrf-token') || '';
   const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement | null;
   const successMsg = document.getElementById('success-message') as HTMLDivElement | null;
   const errorMsg = document.getElementById('error-message') as HTMLDivElement | null;
@@ -236,6 +240,7 @@ if (!session) return Astro.redirect('/auth/login');
           newPassword,
           newPasswordConfirm,
           revokeOtherSessions,
+          csrf_token: csrfToken,
         }),
       });
 


### PR DESCRIPTION
## Summary
Fixes password change form that was failing with 403 Forbidden after CSRF validation was enabled on the endpoint.

## Root Cause
PR #232 added CSRF validation to `/api/auth/change-password` endpoint, but the frontend wasn't sending the token.

## Changes
- Get `csrfToken` from session in frontmatter
- Add `data-csrf-token` attribute to form element
- Read CSRF token from data attribute in script (avoids TypeScript incompatibility with `define:vars`)
- Add `csrf_token` to request body

## CSRF Protection Status
This completes the CSRF protection rollout:

✅ `/api/pim/drop` - Drop access button (PR #236)
✅ `/api/pim/extend` - Extend access button (PR #236)
✅ `/api/owners` (POST/PUT/DELETE) - Already working
✅ `/api/auth/change-password` - **This PR**

All state-changing endpoints now have CSRF validation with frontend properly sending tokens.

## Test Plan
1. Navigate to `/portal/profile/security` → "Change Password"
2. Fill out form with current and new passwords
3. Submit - should succeed instead of 403 error
4. Verify password changed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)