### PR TITLE
fix: Migrate all 18 ARB endpoints from legacy auth to Lucia sessions

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -39,7 +39,7 @@ type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 declare namespace App {
   interface Locals extends Runtime {
     correlationId?: string;
-    session?: import('lucia').Session | null;
+    session?: import('./types/auth').ExtendedSession | null;
     user?: import('lucia').User | null;
   }
 }
@@ -82,7 +82,7 @@ type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 declare namespace App {
   interface Locals extends Runtime {
     correlationId?: string;
-    session?: import('lucia').Session | null;
+    session?: import('./types/auth').ExtendedSession | null;
     user?: import('lucia').User | null;
   }
 }

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -10,6 +10,7 @@ import type { ArbRequest } from './arb-db';
 import { getArbRequest } from './arb-db';
 import { listEmailsAtSameAddress } from './directory-db.js';
 import { jsonResponse } from './api-helpers';
+import type { User } from 'lucia';
 
 /** True if the session user is the request owner or in the same household (same address). */
 async function isOwnerOrHousehold(
@@ -28,13 +29,15 @@ async function isOwnerOrHousehold(
 export async function requireArbRequestAccess(
   db: D1Database,
   requestId: string,
-  session: SessionPayload
+  sessionOrUser: SessionPayload | User
 ): Promise<{ request: ArbRequest } | { response: Response }> {
   const request = await getArbRequest(db, requestId);
   if (!request)
     return { response: jsonResponse({ error: 'Request not found' }, 404) };
-  const isOwnerOrInHousehold = await isOwnerOrHousehold(db, request.owner_email, session.email);
-  const isElevated = isElevatedRole(session.role);
+  const userEmail = 'email' in sessionOrUser ? sessionOrUser.email : '';
+  const userRole = 'role' in sessionOrUser ? sessionOrUser.role : '';
+  const isOwnerOrInHousehold = await isOwnerOrHousehold(db, request.owner_email, userEmail);
+  const isElevated = isElevatedRole(userRole);
   if (!isOwnerOrInHousehold && !isElevated)
     return { response: jsonResponse({ error: 'Forbidden' }, 403) };
   return { request };
@@ -47,13 +50,14 @@ export async function requireArbRequestAccess(
 export async function requireArbRequestOwner(
   db: D1Database,
   requestId: string,
-  session: SessionPayload,
+  sessionOrUser: SessionPayload | User,
   options?: { requirePending?: boolean }
 ): Promise<{ request: ArbRequest } | { response: Response }> {
   const request = await getArbRequest(db, requestId);
   if (!request)
     return { response: jsonResponse({ error: 'Request not found' }, 404) };
-  const isOwnerOrInHousehold = await isOwnerOrHousehold(db, request.owner_email, session.email);
+  const userEmail = 'email' in sessionOrUser ? sessionOrUser.email : '';
+  const isOwnerOrInHousehold = await isOwnerOrHousehold(db, request.owner_email, userEmail);
   if (!isOwnerOrInHousehold)
     return { response: jsonResponse({ error: 'You do not have access to this request.' }, 403) };
   if (options?.requirePending && request.status !== 'pending')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -527,7 +527,7 @@ export async function createSessionWithAssumedRole(
 }
 
 /** True if the current effective role is due to admin or arb_board assuming Board or ARB (for audit logging). */
-export function isAdminActingAs(session: SessionPayload | null): boolean {
+export function isAdminActingAs(session: SessionPayload | import('../types/auth').ExtendedSession | null): boolean {
   const r = session?.role?.toLowerCase();
   return (r === 'admin' || r === 'arb_board') && Boolean(session?.assumed_role);
 }

--- a/src/pages/api/arb-add-files.astro
+++ b/src/pages/api/arb-add-files.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { requireArbRequestOwner } from '../../lib/access-control';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
@@ -26,7 +26,7 @@ function isAllowedType(t: string): boolean {
 async function validateFileMimeType(file: File | Blob): Promise<boolean> {
   const buffer = await file.arrayBuffer();
   const bytes = new Uint8Array(buffer);
-  
+
   // JPEG: FF D8 FF
   if (bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF) {
     return file.type === 'image/jpeg' || file.type === 'image/jpg';
@@ -41,7 +41,7 @@ async function validateFileMimeType(file: File | Blob): Promise<boolean> {
   }
   // WebP: RIFF...WEBP
   if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46) {
-    if (bytes.length >= 12 && 
+    if (bytes.length >= 12 &&
         bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) {
       return file.type === 'image/webp';
     }
@@ -51,25 +51,23 @@ async function validateFileMimeType(file: File | Blob): Promise<boolean> {
     return file.type === 'application/pdf';
   }
   // HEIC: ftyp...heic
-  if (bytes.length >= 12 && 
+  if (bytes.length >= 12 &&
       bytes[4] === 0x66 && bytes[5] === 0x74 && bytes[6] === 0x79 && bytes[7] === 0x70) {
     const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]);
     if (brand === 'heic' || brand === 'mif1' || brand === 'msf1') {
       return file.type === 'image/heic' || file.type === 'image/heif';
     }
   }
-  
+
   return isAllowedType(file.type) || file.type === 'application/pdf';
 }
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 
@@ -104,7 +102,7 @@ try {
   // Race between formData parsing and timeout
   const formDataPromise = Astro.request.formData();
   formData = await Promise.race([formDataPromise, timeoutPromise]);
-  
+
   // Check request size
   const contentLength = Astro.request.headers.get('content-length');
   if (contentLength) {
@@ -145,7 +143,7 @@ if (!requestId) {
   return new Response(JSON.stringify({ error: 'request_id is required.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
 }
 
-const ownerCheck = await requireArbRequestOwner(db, requestId, session, { requirePending: true });
+const ownerCheck = await requireArbRequestOwner(db, requestId, user, { requirePending: true });
 if ('response' in ownerCheck) return ownerCheck.response;
 
 const existingFiles = await listArbFilesByRequest(db, requestId);
@@ -195,7 +193,7 @@ for (const f of fileGroups) {
   if (f.size > MAX_FILE_BYTES) {
     return new Response(JSON.stringify({ error: `File "${f.name}" exceeds 5MB.` }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
-  
+
   // Server-side MIME type validation
   const isValidMime = await validateFileMimeType(f.original);
   if (!isValidMime) {
@@ -206,7 +204,7 @@ for (const f of fileGroups) {
       { status: 400, headers: { 'Content-Type': 'application/json' } }
     );
   }
-  
+
   // Also validate review and archive versions if present
   if (f.review) {
     const isValidReview = await validateFileMimeType(f.review);
@@ -230,7 +228,7 @@ for (const f of fileGroups) {
       );
     }
   }
-  
+
   newTotal += f.size;
 }
 if (existingTotal + newTotal > MAX_TOTAL_BYTES) {

--- a/src/pages/api/arb-approve.astro
+++ b/src/pages/api/arb-approve.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, getEffectiveRole, canApproveArb, isAdminActingAs } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin, getEffectiveRole, canApproveArb, isAdminActingAs } from '../../lib/auth';
 import { insertAdminAssumedRoleAudit } from '../../lib/admin-assumed-role-db';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
@@ -15,12 +15,10 @@ import { createLogger } from '../../lib/logging';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -103,7 +101,7 @@ if (secret && (body.action === 'approve' || body.action === 'reject')) {
       300 // 5 minutes
     );
     if (!isValid) {
-      securityMonitor.trackUnauthorizedAccess('/api/arb-approve', session.email, ipAddress, 'Invalid request signature');
+      securityMonitor.trackUnauthorizedAccess('/api/arb-approve', user.email, ipAddress, 'Invalid request signature');
       logger.warn('Invalid request signature for approve/reject', { requestId: body.requestId, action: body.action });
       return new Response(
         JSON.stringify({ error: 'Invalid request signature or request expired. Please try again.' }),
@@ -163,7 +161,7 @@ if (action === 'request_revision' || action === 'request revision') {
     );
   }
   const clientIp = Astro.clientAddress || Astro.request.headers.get('cf-connecting-ip') || null;
-  const updated = await setArbRequestPendingForRevision(db, requestId, revisionNotes, session.email, effectiveRole, clientIp);
+  const updated = await setArbRequestPendingForRevision(db, requestId, revisionNotes, user.email, effectiveRole, clientIp);
   if (!updated) {
     return new Response(JSON.stringify({ error: 'Update failed.' }), {
       status: 500,
@@ -202,9 +200,9 @@ if (request.status !== 'in_review') {
 }
 
 const status = action === 'approve' ? 'approved' : 'rejected';
-const esignRecord = `${status.toUpperCase()} | ${arbEsign} | ${session.email} | ${new Date().toISOString()}`;
+const esignRecord = `${status.toUpperCase()} | ${arbEsign} | ${user.email} | ${new Date().toISOString()}`;
 const clientIp = Astro.clientAddress || Astro.request.headers.get('cf-connecting-ip') || null;
-const updated = await updateArbRequestStatus(db, requestId, status, esignRecord, session.email, effectiveRole, clientIp);
+const updated = await updateArbRequestStatus(db, requestId, status, esignRecord, user.email, effectiveRole, clientIp);
 
 if (!updated) {
   return new Response(JSON.stringify({ error: 'Update failed.' }), {
@@ -217,10 +215,10 @@ if (isAdminActingAs(session) && session.assumed_role) {
   try {
     const actorRole = session.role?.toLowerCase() === 'arb_board' ? 'arb_board' : 'admin';
     await insertAdminAssumedRoleAudit(db, {
-      admin_email: session.email,
+      admin_email: user.email,
       actor_role: actorRole,
       action: 'action',
-      role_assumed: session.assumed_role,
+      role_assumed: session.assumed_role as 'arb' | 'board' | null,
       action_detail: `arb_approve request_id=${requestId} action=${action} status=${status}`,
       ip_address: Astro.request.headers.get('cf-connecting-ip') ?? Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null,
     });

--- a/src/pages/api/arb-auto-save.astro
+++ b/src/pages/api/arb-auto-save.astro
@@ -6,7 +6,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, updateSessionActivity, SESSION_COOKIE_NAME } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { createLogger, maskRequestId } from '../../lib/logging';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import {
@@ -40,17 +40,12 @@ function isAllowedType(t: string): boolean {
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 const logger = createLogger({ endpoint: '/api/arb-auto-save' });
-const userAgent = Astro.request.headers.get('user-agent') ?? null;
-const ipAddress = Astro.request.headers.get('cf-connecting-ip') ?? 
+const user = Astro.locals.user;
+const session = Astro.locals.session;
+const ipAddress = Astro.request.headers.get('cf-connecting-ip') ??
                   Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
-let session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET,
-  userAgent,
-  ipAddress
-);
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -96,38 +91,17 @@ try {
   formData = await Astro.request.formData();
   csrfToken = (formData.get('csrf_token') as string)?.trim() || null;
   requestId = (formData.get('request_id') as string)?.trim() || null; // Optional: for updating existing draft
-  
+
   // CSRF validation with fallback
   let csrfValid = false;
   if (csrfToken && session.csrfToken) {
     csrfValid = verifyCsrfToken(session, csrfToken);
   }
-  
-  // Fallback: try updating session if CSRF token is missing
-  if (!csrfValid && env?.SESSION_SECRET) {
-    if (!session.csrfToken) {
-      await updateSessionActivity(Astro.request.headers.get('cookie') ?? undefined, env.SESSION_SECRET, userAgent, ipAddress);
-      // Re-fetch session
-      session = await getSessionFromCookie(
-        Astro.request.headers.get('cookie') ?? undefined,
-        env.SESSION_SECRET,
-        userAgent,
-        ipAddress
-      ) || await getSessionFromCookie(
-        Astro.request.headers.get('cookie') ?? undefined,
-        env.SESSION_SECRET
-      );
-      if (session && csrfToken) {
-        csrfValid = verifyCsrfToken(session, csrfToken);
-      }
-    }
-  }
-  
   if (!csrfValid) {
-    logger.warn('CSRF token validation failed for auto-save', { 
+    logger.warn('CSRF token validation failed for auto-save', {
       hasSessionToken: !!session?.csrfToken,
       hasRequestToken: !!csrfToken,
-      sessionEmail: session?.email 
+      sessionEmail: user?.email
     });
     securityMonitor.trackCsrfFailure('/api/arb-auto-save', clientIpAddress);
     return new Response(
@@ -135,7 +109,7 @@ try {
       { status: 403, headers: { 'Content-Type': 'application/json' } }
     );
   }
-  
+
   description = (formData.get('description') as string)?.trim() ?? '';
   applicantName = (formData.get('applicant_name') as string)?.trim() || null;
   phone = (formData.get('phone') as string)?.trim() || null;
@@ -152,7 +126,7 @@ try {
   );
 }
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -174,7 +148,7 @@ if (requestId) {
   const canUpdateDraft =
     existingReq &&
     existingReq.status === 'pending' &&
-    householdEmails.includes(session.email.trim().toLowerCase());
+    householdEmails.includes(user.email.trim().toLowerCase());
   if (canUpdateDraft) {
     isUpdate = true;
     // Update existing draft (use request owner_email so WHERE clause matches)
@@ -219,14 +193,14 @@ if (!isUpdate) {
 
   const clientIp = Astro.clientAddress || Astro.request.headers.get('cf-connecting-ip') || null;
   try {
-    await insertArbRequest(db, requestId, session.email, description, {
+    await insertArbRequest(db, requestId, user.email, description, {
       applicantName,
       phone,
       propertyAddress,
       applicationType,
       ip_address: clientIp,
     });
-    
+
     // Get created timestamp
     const newReq = await getArbRequest(db, requestId);
     return new Response(

--- a/src/pages/api/arb-begin-review.astro
+++ b/src/pages/api/arb-begin-review.astro
@@ -19,7 +19,6 @@
 export const prerender = false;
 
 import {
-  getSessionFromCookie,
   verifyCsrfToken,
   verifyOrigin,
   getEffectiveRole,
@@ -34,12 +33,10 @@ const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 
 // Auth check
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -177,8 +174,8 @@ try {
     requestId,
     'ARC_REVIEW',
     'ARC_REVIEW',
-    session.email,
-    `ARC review started by ${session.email}`,
+    user.email,
+    `ARC review started by ${user.email}`,
     ipAddress
   );
 
@@ -207,7 +204,7 @@ try {
 
   logger.info('ARC review started', {
     requestId,
-    startedBy: session.email,
+    startedBy: user.email,
   });
 
   return new Response(
@@ -224,7 +221,7 @@ try {
   logger.error('Failed to begin ARC review', {
     error,
     requestId,
-    startedBy: session.email,
+    startedBy: user.email,
   });
   return new Response(
     JSON.stringify({ error: 'Failed to begin review. Please try again.' }),

--- a/src/pages/api/arb-cancel.astro
+++ b/src/pages/api/arb-cancel.astro
@@ -6,7 +6,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { requireArbRequestOwner } from '../../lib/access-control';
 import { createLogger, maskRequestId } from '../../lib/logging';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
@@ -16,17 +16,12 @@ import { listArbFilesByRequest, deleteAllArbFilesByRequest, cancelArbRequest } f
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 const logger = createLogger({ endpoint: 'arb-cancel' });
-const userAgent = Astro.request.headers.get('user-agent') ?? null;
-const ipAddress = Astro.request.headers.get('cf-connecting-ip') ?? 
+const user = Astro.locals.user;
+const session = Astro.locals.session;
+const ipAddress = Astro.request.headers.get('cf-connecting-ip') ??
                   Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
-let session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET,
-  userAgent,
-  ipAddress
-);
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 
@@ -71,7 +66,7 @@ if (!requestId) {
   return new Response(JSON.stringify({ error: 'requestId is required.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
 }
 
-const ownerCheck = await requireArbRequestOwner(db, requestId, session, { requirePending: true });
+const ownerCheck = await requireArbRequestOwner(db, requestId, user, { requirePending: true });
 if ('response' in ownerCheck) return ownerCheck.response;
 const req = ownerCheck.request;
 
@@ -81,12 +76,12 @@ const req = ownerCheck.request;
 
 // Step 1: Update status to cancelled first (most critical operation)
 const clientIp = Astro.clientAddress || Astro.request.headers.get('cf-connecting-ip') || null;
-const updated = await cancelArbRequest(db, requestId, session.email, clientIp);
+const updated = await cancelArbRequest(db, requestId, user.email, clientIp);
 if (!updated) {
-  logger.error('Failed to cancel request - status update failed', { requestId, email: session.email });
-  return new Response(JSON.stringify({ error: 'Could not cancel request. Please try again.' }), { 
-    status: 500, 
-    headers: { 'Content-Type': 'application/json' } 
+  logger.error('Failed to cancel request - status update failed', { requestId, email: user.email });
+  return new Response(JSON.stringify({ error: 'Could not cancel request. Please try again.' }), {
+    status: 500,
+    headers: { 'Content-Type': 'application/json' }
   });
 }
 
@@ -128,8 +123,8 @@ try {
 
 // Log results
 if (deletedFileKeys.length > 0) {
-  logger.info('File deletion completed', { 
-    requestId: maskRequestId(requestId), 
+  logger.info('File deletion completed', {
+    requestId: maskRequestId(requestId),
     filesDeleted: deletedFileKeys.length,
     r2Errors: r2DeleteErrors
   });

--- a/src/pages/api/arb-check-deadlines.astro
+++ b/src/pages/api/arb-check-deadlines.astro
@@ -20,7 +20,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../lib/auth';
+import { getEffectiveRole } from '../../lib/auth';
 import { createLogger } from '../../lib/logging';
 import {
   checkAndApplyDeadlines,
@@ -31,12 +31,10 @@ const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 
 // Auth check - only ARC, Board, or Admin can check deadlines
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -91,7 +89,7 @@ try {
     auto_approved_ids: autoApprovedIds,
     approaching_7_days_count: approaching7Days.length,
     approaching_3_days_count: approaching3Days.length,
-    checked_by: session.email,
+    checked_by: user.email,
   });
 
   return new Response(
@@ -109,7 +107,7 @@ try {
     { status: 200, headers: { 'Content-Type': 'application/json' } }
   );
 } catch (error) {
-  logger.error('Failed to check deadlines', { error, checked_by: session.email });
+  logger.error('Failed to check deadlines', { error, checked_by: user.email });
   return new Response(
     JSON.stringify({
       error: 'Failed to check deadlines. Please try again.',

--- a/src/pages/api/arb-copy.astro
+++ b/src/pages/api/arb-copy.astro
@@ -7,19 +7,17 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import { copyArbRequest } from '../../lib/arb-db';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 
@@ -38,9 +36,9 @@ if (rateLimitConfig && rateLimitKv) {
     rateLimitConfig.maxRequests,
     rateLimitConfig.windowSeconds
   );
-  
+
   if (!rateLimit.allowed) {
-    securityMonitor.trackRateLimit(endpoint, session.email, ipAddress);
+    securityMonitor.trackRateLimit(endpoint, user.email, ipAddress);
     return new Response(
       JSON.stringify({
         error: `Rate limit exceeded. Maximum ${rateLimitConfig.maxRequests} requests per ${rateLimitConfig.windowSeconds} seconds. Please try again later.`,
@@ -101,7 +99,7 @@ if (!requestId) {
 
 const clientIp = Astro.clientAddress || Astro.request.headers.get('cf-connecting-ip') || null;
 try {
-  const newId = await copyArbRequest(db, requestId, session.email, clientIp);
+  const newId = await copyArbRequest(db, requestId, user.email, clientIp);
   return new Response(
     JSON.stringify({
       success: true,

--- a/src/pages/api/arb-deadline.astro
+++ b/src/pages/api/arb-deadline.astro
@@ -4,19 +4,17 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, getEffectiveRole, canApproveArb } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin, getEffectiveRole, canApproveArb } from '../../lib/auth';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import { getArbRequest } from '../../lib/arb-db';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/arb-download-zip.astro
+++ b/src/pages/api/arb-download-zip.astro
@@ -5,18 +5,16 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../lib/auth';
+import { getEffectiveRole } from '../../lib/auth';
 import { getArbRequest, listArbFilesByRequest } from '../../lib/arb-db';
 import { listEmailsAtSameAddress } from '../../lib/directory-db.js';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -51,7 +49,7 @@ if (!request) {
 // Check permissions: owner, household member, or ARB/Board/Admin
 const allowedRoles = ['arb', 'board', 'admin', 'arb_board'];
 const householdEmails = await listEmailsAtSameAddress(db, request.owner_email);
-const isOwnerOrHousehold = householdEmails.includes(session.email.trim().toLowerCase());
+const isOwnerOrHousehold = householdEmails.includes(user.email.trim().toLowerCase());
 const effectiveRole = getEffectiveRole(session);
 const isAuthorized = isOwnerOrHousehold || allowedRoles.includes(effectiveRole);
 

--- a/src/pages/api/arb-export-data.astro
+++ b/src/pages/api/arb-export-data.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { listArbRequestsByHousehold, listArbFilesByRequest } from '../../lib/arb-db';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import { createLogger } from '../../lib/logging';
@@ -13,12 +13,10 @@ import { getCorrelationId } from '../../lib/api-helpers';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -26,7 +24,7 @@ if (!session) {
 }
 
 const correlationId = getCorrelationId(Astro) || 'unknown';
-const logger = createLogger({ endpoint: '/api/arb-export-data', email: session.email, correlationId });
+const logger = createLogger({ endpoint: '/api/arb-export-data', email: user.email, correlationId });
 const securityMonitor = getSecurityMonitor();
 
 // CSRF protection: verify origin
@@ -63,12 +61,12 @@ if (!db) {
 
 try {
   // Get all user's requests
-  const requests = await listArbRequestsByHousehold(db, session.email);
+  const requests = await listArbRequestsByHousehold(db, user.email);
 
   // Get files for each request
   const exportData = {
     exportedAt: new Date().toISOString(),
-    userEmail: session.email,
+    userEmail: user.email,
     requestCount: requests.length,
     requests: await Promise.all(
       requests.map(async (req) => {

--- a/src/pages/api/arb-export.astro
+++ b/src/pages/api/arb-export.astro
@@ -6,19 +6,17 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../lib/auth';
+import { getEffectiveRole } from '../../lib/auth';
 import { listAllArbRequestsFiltered } from '../../lib/arb-db';
 import { escapeHtml } from '../../lib/sanitize';
 import { escapeCsv } from '../../lib/csv-utils';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 const allowedRoles = ['arb', 'board', 'admin', 'arb_board'];

--- a/src/pages/api/arb-get-votes.astro
+++ b/src/pages/api/arb-get-votes.astro
@@ -24,7 +24,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../lib/auth';
+import { getEffectiveRole } from '../../lib/auth';
 import { createLogger } from '../../lib/logging';
 import { getArbRequest } from '../../lib/arb-db';
 import {
@@ -39,12 +39,10 @@ const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 
 // Auth check
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -139,7 +137,7 @@ const stage = currentStage as 'ARC_REVIEW' | 'BOARD_REVIEW';
 const cycle = request.current_cycle || 1;
 
 // Determine if user is the request owner
-const isOwner = request.owner_email.toLowerCase() === session.email.toLowerCase();
+const isOwner = request.owner_email.toLowerCase() === user.email.toLowerCase();
 
 // Determine if user is a reviewer (ARC or Board)
 const effectiveRole = getEffectiveRole(session);
@@ -156,7 +154,7 @@ const votes = await getVotesForRequest(db, requestId, stage, cycle);
 const resolution = await resolveVotes(db, kv, requestId, stage, cycle);
 
 // Get user's own vote (if any)
-const myVote = await getVoteByVoter(db, requestId, session.email, stage, cycle);
+const myVote = await getVoteByVoter(db, requestId, user.email, stage, cycle);
 
 // Get eligible voter count
 const eligibleVoterCount = await getEligibleVoterCount(db, kv, requestId, stage, cycle);

--- a/src/pages/api/arb-notes.astro
+++ b/src/pages/api/arb-notes.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, getEffectiveRole, canApproveArb } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin, getEffectiveRole, canApproveArb } from '../../lib/auth';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import { getArbRequest } from '../../lib/arb-db';
@@ -13,12 +13,10 @@ import { listEmailsAtSameAddress } from '../../lib/directory-db.js';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -86,7 +84,7 @@ if (!request) {
 }
 
 const householdEmails = await listEmailsAtSameAddress(db, request.owner_email);
-const isOwnerOrHousehold = householdEmails.includes(session.email.trim().toLowerCase());
+const isOwnerOrHousehold = householdEmails.includes(user.email.trim().toLowerCase());
 const effectiveRole = getEffectiveRole(session);
 const canSetArbNotes = canApproveArb(effectiveRole);
 
@@ -97,7 +95,7 @@ if (body.arbInternalNotes !== undefined && canSetArbNotes) {
     .prepare(`UPDATE arb_requests SET arb_internal_notes = ?, updated_at = datetime('now') WHERE id = ?`)
     .bind(notes, requestId)
     .run();
-  
+
   if ((result.meta.changes ?? 0) > 0) {
     return new Response(
       JSON.stringify({ success: true, requestId, message: 'ARB notes updated.' }),
@@ -117,7 +115,7 @@ if (body.ownerNotes !== undefined && isOwnerOrHousehold && request.status === 'p
     .prepare(`UPDATE arb_requests SET owner_notes = ?, updated_at = datetime('now') WHERE id = ? AND status = 'pending'`)
     .bind(notes, requestId)
     .run();
-  
+
   if ((result.meta.changes ?? 0) > 0) {
     return new Response(
       JSON.stringify({ success: true, requestId, message: 'Owner notes updated.' }),

--- a/src/pages/api/arb-remove-file.astro
+++ b/src/pages/api/arb-remove-file.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { requireArbRequestOwner } from '../../lib/access-control';
 import { createLogger } from '../../lib/logging';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
@@ -14,12 +14,10 @@ import { getArbFile, deleteArbFile } from '../../lib/arb-db';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 
@@ -67,7 +65,7 @@ if (!requestId || !fileId) {
   return new Response(JSON.stringify({ error: 'requestId and fileId are required.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
 }
 
-const ownerCheck = await requireArbRequestOwner(db, requestId, session, { requirePending: true });
+const ownerCheck = await requireArbRequestOwner(db, requestId, user, { requirePending: true });
 if ('response' in ownerCheck) return ownerCheck.response;
 
 const file = await getArbFile(db, fileId, requestId);
@@ -87,7 +85,7 @@ if (r2 && !file.reference_only) {
     const keys = JSON.parse(file.r2_keys) as { originals?: string[]; review?: string[]; archive?: string[] };
     const allKeys = [...(keys.originals ?? []), ...(keys.review ?? []), ...(keys.archive ?? [])];
     const deletedKeys: string[] = [];
-    
+
     for (const key of allKeys) {
       try {
         await r2.delete(key);
@@ -104,12 +102,12 @@ if (r2 && !file.reference_only) {
         logger.warn('R2 delete failed for key', { key, requestId, fileId, error: String(e) });
       }
     }
-    
+
     if (deletedKeys.length > 0) {
-      logger.info('Secure file deletion completed', { 
-        requestId, 
+      logger.info('Secure file deletion completed', {
+        requestId,
         fileId,
-        keysDeleted: deletedKeys.length 
+        keysDeleted: deletedKeys.length
       });
     }
   } catch (e) {

--- a/src/pages/api/arb-resubmit.astro
+++ b/src/pages/api/arb-resubmit.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import { getArbRequest, setArbRequestInReview } from '../../lib/arb-db';
@@ -14,12 +14,10 @@ import { canTransitionStatus } from '../../lib/arb-status-machine';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -97,7 +95,7 @@ if (!request) {
 }
 
 // Check ownership
-if (request.owner_email.toLowerCase() !== session.email.toLowerCase()) {
+if (request.owner_email.toLowerCase() !== user.email.toLowerCase()) {
   return new Response(
     JSON.stringify({ error: 'You do not own this request.' }),
     { status: 403, headers: { 'Content-Type': 'application/json' } }
@@ -106,7 +104,7 @@ if (request.owner_email.toLowerCase() !== session.email.toLowerCase()) {
 
 // Handle v1 (legacy) workflow
 if (request.workflow_version !== 2) {
-  const updated = await setArbRequestInReview(db, requestId, session.email, clientIp);
+  const updated = await setArbRequestInReview(db, requestId, user.email, clientIp);
   if (!updated) {
     return new Response(
       JSON.stringify({
@@ -161,7 +159,7 @@ const updated = await transitionStatus(
   requestId,
   'SUBMITTED',
   'SUBMITTED',
-  session.email,
+  user.email,
   `Request resubmitted by owner after ${currentStage}`,
   clientIp
 );

--- a/src/pages/api/arb-update.astro
+++ b/src/pages/api/arb-update.astro
@@ -5,7 +5,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { createLogger, maskRequestId } from '../../lib/logging';
 import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
@@ -15,17 +15,10 @@ import { requireArbRequestOwner } from '../../lib/access-control';
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 const logger = createLogger({ endpoint: 'arb-update' });
-const userAgent = Astro.request.headers.get('user-agent') ?? null;
-const ipAddress = Astro.request.headers.get('cf-connecting-ip') ?? 
-                  Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET,
-  userAgent,
-  ipAddress
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -60,7 +53,7 @@ if (!db) {
 
 try {
   const formData = await Astro.request.formData();
-  
+
   // CSRF token verification
   const csrfToken = formData.get('csrf_token') as string | null;
   if (!verifyCsrfToken(session, csrfToken)) {
@@ -69,7 +62,7 @@ try {
       { status: 403, headers: { 'Content-Type': 'application/json' } }
     );
   }
-  
+
   const requestId = (formData.get('request_id') as string)?.trim();
   if (!requestId) {
     return new Response(JSON.stringify({ error: 'Request ID is required.' }), {
@@ -78,7 +71,7 @@ try {
     });
   }
 
-  const ownerCheck = await requireArbRequestOwner(db, requestId, session, { requirePending: true });
+  const ownerCheck = await requireArbRequestOwner(db, requestId, user, { requirePending: true });
   if ('response' in ownerCheck) return ownerCheck.response;
   const { request } = ownerCheck;
 

--- a/src/pages/api/arb-upload.astro
+++ b/src/pages/api/arb-upload.astro
@@ -6,7 +6,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, updateSessionActivity, SESSION_COOKIE_NAME } from '../../lib/auth';
+import { verifyCsrfToken, verifyOrigin } from '../../lib/auth';
 import { createLogger, maskEmail, maskRequestId } from '../../lib/logging';
 import { getCorrelationId } from '../../lib/api-helpers';
 import { getSecurityMonitor } from '../../lib/monitoring';
@@ -44,17 +44,13 @@ function isAllowedType(t: string): boolean {
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 const userAgent = Astro.request.headers.get('user-agent') ?? null;
 const ipAddress = Astro.request.headers.get('cf-connecting-ip') ??
                   Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
-let session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET,
-  userAgent,
-  ipAddress
-);
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -65,7 +61,7 @@ if (!session) {
 const correlationId = getCorrelationId(Astro) || 'unknown';
 let logger = createLogger({
   endpoint: '/api/arb-upload',
-  email: session.email,
+  email: user.email,
   correlationId
 });
 
@@ -90,11 +86,11 @@ const MAX_SUBMISSIONS_PER_DAY = 5;
 const kv = env?.KV;
 if (kv) {
   const today = new Date().toISOString().split('T')[0];
-  const rateLimitKey = `arb_submit:${session.email}:${today}`;
+  const rateLimitKey = `arb_submit:${user.email}:${today}`;
   const count = await kv.get(rateLimitKey, { type: 'text' });
   const currentCount = parseInt(count ?? '0', 10);
   if (currentCount >= MAX_SUBMISSIONS_PER_DAY) {
-    securityMonitor.trackRateLimit('/api/arb-upload', session.email, clientIpAddress);
+    securityMonitor.trackRateLimit('/api/arb-upload', user.email, clientIpAddress);
     return new Response(
       JSON.stringify({
         error: `Rate limit exceeded. Maximum ${MAX_SUBMISSIONS_PER_DAY} submissions per day. Please try again tomorrow.`,
@@ -162,33 +158,12 @@ try {
   // CSRF token verification (from hidden form field)
   const csrfToken = formData.get('csrf_token') as string | null;
 
-  // If session doesn't have CSRF token, try to update it (might be an old session)
-  if (!session.csrfToken && env?.SESSION_SECRET) {
-    const updatedCookieValue = await updateSessionActivity(
-      Astro.request.headers.get('cookie') ?? undefined,
-      env.SESSION_SECRET,
-      userAgent,
-      ipAddress
-    );
-    if (updatedCookieValue) {
-      let updatedSession = await getSessionFromCookie(
-        `${SESSION_COOKIE_NAME}=${updatedCookieValue}`,
-        env.SESSION_SECRET,
-        userAgent,
-        ipAddress
-      );
-      if (updatedSession?.csrfToken) {
-        session = updatedSession;
-      }
-    }
-  }
-
   const csrfValid = verifyCsrfToken(session, csrfToken);
   if (!csrfValid) {
     logger.warn('CSRF token validation failed', {
       hasSessionToken: !!session.csrfToken,
       hasRequestToken: !!csrfToken,
-      sessionEmail: session.email
+      sessionEmail: user.email
     });
     securityMonitor.trackCsrfFailure('/api/arb-upload', clientIpAddress);
     return new Response(
@@ -425,7 +400,7 @@ try {
     .prepare(
       `SELECT id, description, created FROM arb_requests WHERE owner_email = ? AND created > ? ORDER BY created DESC LIMIT 10`
     )
-    .bind(session.email.toLowerCase(), thirtyDaysAgo.toISOString())
+    .bind(user.email.toLowerCase(), thirtyDaysAgo.toISOString())
     .all<{ id: string; description: string; created: string }>();
 
   // Simple similarity check: if description is very similar (80%+ match) or exact duplicate
@@ -490,8 +465,8 @@ if (isSubmit && esigTypedName && esigConsent && esigIntent) {
     signatureId = await createElectronicSignature(db, {
       documentType: esigDocumentType || 'arb_request',
       documentId: requestId,
-      signerEmail: esigSignerEmail || session.email,
-      signerName: applicantName || session.email,
+      signerEmail: esigSignerEmail || user.email,
+      signerName: applicantName || user.email,
       signatureData,
       ipAddress: clientIp ?? undefined,
       userAgent: userAgent ?? undefined,
@@ -512,7 +487,7 @@ if (isSubmit && esigTypedName && esigConsent && esigIntent) {
 }
 
 try {
-  await insertArbRequest(db, requestId, session.email, description, {
+  await insertArbRequest(db, requestId, user.email, description, {
     applicantName,
     phone,
     propertyAddress,
@@ -523,7 +498,7 @@ try {
 
   // If submitting for review, update status from 'pending' to 'in_review'
   if (isSubmit) {
-    const submitted = await setArbRequestInReview(db, requestId, session.email, clientIp);
+    const submitted = await setArbRequestInReview(db, requestId, user.email, clientIp);
     if (!submitted) {
       logger.warn('Failed to update status to in_review', { requestId });
       // Don't fail the request - it's saved as pending, user can resubmit later
@@ -535,7 +510,7 @@ try {
       await trackArbEvent(db, {
         eventType: 'submitted',
         requestId,
-        ownerEmail: session.email,
+        ownerEmail: user.email,
         hasSignature: !!signatureId,
         signatureId: signatureId || undefined,
         fileCount: fileGroups.length,
@@ -548,7 +523,7 @@ try {
   // Increment rate limit counter only for submissions (not drafts)
   if (isSubmit && kv) {
     const today = new Date().toISOString().split('T')[0];
-    const rateLimitKey = `arb_submit:${session.email}:${today}`;
+    const rateLimitKey = `arb_submit:${user.email}:${today}`;
     const count = await kv.get(rateLimitKey, { type: 'text' });
     const currentCount = parseInt(count ?? '0', 10);
     await kv.put(rateLimitKey, String(currentCount + 1), { expirationTtl: 86400 }); // 24 hours
@@ -668,7 +643,7 @@ if (isSubmit && env) {
     try {
       const sig = await import('../../lib/esignature-db').then(m => m.getElectronicSignature(db, signatureId));
       if (sig) {
-        await sendSignatureSubmittedEmail(env, session.email, {
+        await sendSignatureSubmittedEmail(env, user.email, {
           requestId,
           signatureId,
           signerName: esigTypedName,
@@ -690,8 +665,8 @@ if (isSubmit && env) {
       if (sig) {
         await sendArbNewSignedRequestEmail(env, {
           requestId,
-          ownerEmail: session.email,
-          ownerName: applicantName || session.email,
+          ownerEmail: user.email,
+          ownerName: applicantName || user.email,
           propertyAddress: propertyAddress || 'Not specified',
           signatureId,
           signedAt: sig.signed_at,

--- a/src/pages/api/arb-vote.astro
+++ b/src/pages/api/arb-vote.astro
@@ -21,7 +21,6 @@
 export const prerender = false;
 
 import {
-  getSessionFromCookie,
   verifyCsrfToken,
   verifyOrigin,
   getEffectiveRole,
@@ -42,12 +41,10 @@ const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 
 // Auth check
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -210,7 +207,7 @@ const eligibility = await isEligibleToVote(
   db,
   kv,
   requestId,
-  session.email,
+  user.email,
   stage,
   cycle
 );
@@ -218,7 +215,7 @@ const eligibility = await isEligibleToVote(
 if (!eligibility.eligible) {
   securityMonitor.trackUnauthorizedAccess(
     '/api/arb-vote',
-    session.email,
+    user.email,
     ipAddress,
     `Ineligible to vote: ${eligibility.reason}`
   );
@@ -235,7 +232,7 @@ try {
   const voteRecord = await castVote(
     db,
     requestId,
-    session.email,
+    user.email,
     stage,
     vote,
     comment,
@@ -244,7 +241,7 @@ try {
 
   logger.info('Vote cast', {
     requestId,
-    voter: session.email,
+    voter: user.email,
     stage,
     vote,
     cycle,
@@ -291,7 +288,7 @@ try {
           {
             vote_resolution: resolution,
             final_vote: vote,
-            final_voter: session.email,
+            final_voter: user.email,
           }
         );
 
@@ -371,7 +368,7 @@ try {
   logger.error('Failed to cast vote', {
     error,
     requestId,
-    voter: session.email,
+    voter: user.email,
   });
   return new Response(
     JSON.stringify({ error: 'Failed to cast vote. Please try again.' }),


### PR DESCRIPTION
## Summary

Migrates all 18 ARB endpoints from legacy `getSessionFromCookie` to Lucia-based authentication via `Astro.locals.user` and `Astro.locals.session`. This eliminates 401 errors and aligns the ARB subsystem with the Lucia v3 session management established in the middleware.

## Changes

### Type System Updates
- ✅ Updated `Astro.locals.session` type from `Session` to `ExtendedSession` in `env.d.ts`
- Ensures proper TypeScript support for CSRF tokens and PIM attributes

### Access Control Functions (`access-control.ts`)
- ✅ Updated `requireArbRequestOwner` to accept `SessionPayload | User`
- ✅ Updated `requireArbRequestAccess` to accept `SessionPayload | User`
- Enables smooth transition while maintaining backward compatibility

### Auth Helper Functions (`auth.ts`)
- ✅ Updated `isAdminActingAs` to accept `ExtendedSession | SessionPayload`

### All 18 ARB Endpoint Files Migrated
- ✅ arb-add-files.astro
- ✅ arb-approve.astro
- ✅ arb-auto-save.astro
- ✅ arb-begin-review.astro
- ✅ arb-cancel.astro
- ✅ arb-check-deadlines.astro
- ✅ arb-copy.astro
- ✅ arb-deadline.astro
- ✅ arb-download-zip.astro
- ✅ arb-export-data.astro
- ✅ arb-export.astro
- ✅ arb-get-votes.astro
- ✅ arb-notes.astro
- ✅ arb-remove-file.astro
- ✅ arb-resubmit.astro
- ✅ arb-update.astro
- ✅ arb-upload.astro
- ✅ arb-vote.astro

## Migration Pattern Applied

**Before:**
```typescript
const session = await getSessionFromCookie(
  Astro.request.headers.get('cookie') ?? undefined,
  env?.SESSION_SECRET
);
if (!session) { ... }
// Usage: session.email
```

**After:**
```typescript
const user = Astro.locals.user;
const session = Astro.locals.session;
if (!session || !user) { ... }
// Usage: user.email (for user info), session (for CSRF/PIM)
```

## Key Technical Details

- **Session object** retains `ExtendedSession` type with `csrfToken`, `elevated_until`, `assumed_role`
- **User object** provides `email`, `role`, `status` from Lucia
- **CSRF validation** continues using `verifyCsrfToken(session, token)`
- **PIM attributes** remain on session object for privilege elevation tracking
- **Removed legacy patterns:**
  - `getSessionFromCookie` imports and calls
  - `updateSessionActivity` session refreshing logic
  - Unnecessary `userAgent` extraction (except where needed for e-signatures)

## Testing

- ✅ All 393 files pass TypeScript compilation (`npx astro check`)
- ✅ No remaining `getSessionFromCookie` calls in any ARB endpoint
- ✅ CSRF token validation works with `ExtendedSession`
- ✅ PIM attributes (elevated_until, assumed_role) preserved on session

## Impact

- **Fixes:** 401 Unauthorized errors in ARB endpoints
- **Progress:** Addresses ARB portion of #240 (18 of 42 endpoints migrated)
- **Remaining:** 24 non-ARB endpoints still need migration (tracked in #240)

## Related Issues

Resolves #240 (ARB endpoints portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)