### PR TITLE
fix: Migrate 3 admin endpoints from legacy auth to Lucia sessions

### DIFF
--- a/src/pages/api/admin/assume-role.astro
+++ b/src/pages/api/admin/assume-role.astro
@@ -6,13 +6,14 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, verifyCsrfToken, verifyOrigin, createSessionWithAssumedRole, ASSUMED_ROLES, ASSUMED_ROLE_TTL_MS, type AdminAssumedRole, SESSION_COOKIE_NAME } from '../../../lib/auth';
+import { verifyCsrfToken, verifyOrigin, ASSUMED_ROLE_TTL_MS, type AdminAssumedRole } from '../../../lib/auth';
 import { insertAdminAssumedRoleAudit } from '../../../lib/admin-assumed-role-db';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 const db = env?.DB;
-const secret = env?.SESSION_SECRET;
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 const ipAddress = Astro.request.headers.get('cf-connecting-ip') ?? Astro.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
 
 if (Astro.request.method !== 'POST') {
@@ -22,8 +23,8 @@ if (Astro.request.method !== 'POST') {
   });
 }
 
-if (!secret) {
-  return new Response(JSON.stringify({ error: 'Unavailable' }), { status: 503, headers: { 'Content-Type': 'application/json' } });
+if (!session || !user || !db) {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 
 const origin = Astro.request.headers.get('origin');
@@ -32,15 +33,7 @@ if (!verifyOrigin(origin, referer, Astro.url.origin)) {
   return new Response(JSON.stringify({ error: 'Invalid origin.' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
 }
 
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  secret
-);
-if (!session) {
-  return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
-}
-
-const sessionRole = session.role?.toLowerCase();
+const sessionRole = user.role?.toLowerCase();
 if (sessionRole !== 'admin' && sessionRole !== 'arb_board') {
   return new Response(JSON.stringify({ error: 'Forbidden. Only admins or ARB+Board can assume a role.' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
 }
@@ -62,42 +55,45 @@ if (raw !== 'board' && raw !== 'arb' && raw !== 'none' && raw !== '') {
 }
 const assumed_role: AdminAssumedRole | null = raw === 'none' || raw === '' ? null : (raw as AdminAssumedRole);
 
-const cookieValue = await createSessionWithAssumedRole(
-  Astro.request.headers.get('cookie') ?? undefined,
-  secret,
-  assumed_role
-);
-if (!cookieValue) {
-  return new Response(JSON.stringify({ error: 'Session invalid' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-}
+// Update session in database with assumed role
+const now = Date.now();
+const assumed_until = assumed_role ? now + ASSUMED_ROLE_TTL_MS : null;
 
-if (db) {
-  try {
-    await insertAdminAssumedRoleAudit(db, {
-      admin_email: session.email,
-      actor_role: sessionRole === 'arb_board' ? 'arb_board' : 'admin',
-      action: assumed_role ? 'assume' : 'clear',
-      role_assumed: assumed_role ?? undefined,
-      action_detail: assumed_role ? `${sessionRole} assumed role: ${assumed_role}` : `${sessionRole} cleared assumed role`,
-      ip_address: ipAddress,
-    });
-  } catch (e) {
-    console.error('[admin assume-role] audit insert failed:', e);
+try {
+  // Update session with assumed_role and timestamps
+  if (assumed_role) {
+    await db.prepare(
+      'UPDATE sessions SET assumed_role = ?, assumed_at = ?, assumed_until = ? WHERE id = ?'
+    ).bind(assumed_role, now, assumed_until, session.id).run();
+  } else {
+    // Clear assumed role
+    await db.prepare(
+      'UPDATE sessions SET assumed_role = NULL, assumed_at = NULL, assumed_until = NULL WHERE id = ?'
+    ).bind(session.id).run();
   }
+
+  // Log to audit trail
+  await insertAdminAssumedRoleAudit(db, {
+    admin_email: user.email,
+    actor_role: sessionRole === 'arb_board' ? 'arb_board' : 'admin',
+    action: assumed_role ? 'assume' : 'clear',
+    role_assumed: assumed_role ?? undefined,
+    action_detail: assumed_role ? `${sessionRole} assumed role: ${assumed_role}` : `${sessionRole} cleared assumed role`,
+    ip_address: ipAddress,
+  });
+} catch (e) {
+  console.error('[admin assume-role] failed to update session or audit:', e);
+  return new Response(
+    JSON.stringify({ error: 'Failed to update assumed role' }),
+    { status: 500, headers: { 'Content-Type': 'application/json' } }
+  );
 }
 
-const isProd = import.meta.env.PROD;
-const cookieHeader = `${SESSION_COOKIE_NAME}=${cookieValue}; Path=/; Max-Age=${60 * 60 * 24 * 7}; SameSite=Lax${isProd ? '; Secure' : ''}; HttpOnly`;
-
-const assumed_until = assumed_role ? Date.now() + ASSUMED_ROLE_TTL_MS : undefined;
 return new Response(
   JSON.stringify({ success: true, assumed_role: assumed_role ?? null, assumed_until: assumed_until ?? null }),
   {
     status: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Set-Cookie': cookieHeader,
-    },
+    headers: { 'Content-Type': 'application/json' },
   }
 );
 ---

--- a/src/pages/api/admin/env-check.astro
+++ b/src/pages/api/admin/env-check.astro
@@ -5,10 +5,12 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../../lib/auth';
+import { getEffectiveRole } from '../../../lib/auth';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
 if (Astro.request.method !== 'GET') {
   return new Response(JSON.stringify({ error: 'Method not allowed' }), {
@@ -17,11 +19,7 @@ if (Astro.request.method !== 'GET') {
   });
 }
 
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 }
 

--- a/src/pages/api/admin/permissions.astro
+++ b/src/pages/api/admin/permissions.astro
@@ -8,7 +8,7 @@
  */
 export const prerender = false;
 
-import { getSessionFromCookie, getEffectiveRole } from '../../../lib/auth';
+import { getEffectiveRole } from '../../../lib/auth';
 import {
   getAllPermissions,
   bulkUpdatePermissions,
@@ -18,14 +18,11 @@ import {
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
 const db = env?.DB;
+const user = Astro.locals.user;
+const session = Astro.locals.session;
 
 // Auth check
-const session = await getSessionFromCookie(
-  Astro.request.headers.get('cookie') ?? undefined,
-  env?.SESSION_SECRET
-);
-
-if (!session) {
+if (!session || !user) {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
     status: 401,
     headers: { 'Content-Type': 'application/json' },
@@ -135,7 +132,7 @@ if (method === 'PUT') {
     const result = await bulkUpdatePermissions(
       db,
       permissionMap,
-      session.email,
+      user.email,
       ipAddress
     );
 


### PR DESCRIPTION
## Summary

Migrates 3 admin endpoints from legacy `getSessionFromCookie` to Lucia-based authentication via `Astro.locals.user` and `Astro.locals.session`. This eliminates potential 401 errors and completes the migration of all admin-specific API endpoints.

## Changes

### Admin Endpoints Migrated (3 files)
- ✅ **assume-role.astro** - Admin/ARB+Board role assumption management
- ✅ **env-check.astro** - Environment variable status checker
- ✅ **permissions.astro** - Route permissions CRUD operations

### Migration Pattern Applied

**Standard Pattern:**
```typescript
// Before
const session = await getSessionFromCookie(
  Astro.request.headers.get('cookie') ?? undefined,
  env?.SESSION_SECRET
);
if (!session) { ... }
// Usage: session.email, session.role

// After
const user = Astro.locals.user;
const session = Astro.locals.session;
if (!session || !user) { ... }
// Usage: user.email, user.role (for user info)
//        session (for CSRF/PIM attributes)
```

### assume-role.astro - Significant Refactor

This endpoint required more extensive changes to align with Lucia's session management:

**Before (Legacy Cookie-Based):**
- Called `createSessionWithAssumedRole()` to generate new session cookie
- Returned `Set-Cookie` header with updated session value
- Required `SESSION_SECRET` and cookie manipulation
- Less direct error handling

**After (Lucia D1-Based):**
- Updates `sessions` table directly via D1 SQL:
  ```sql
  UPDATE sessions 
  SET assumed_role = ?, assumed_at = ?, assumed_until = ? 
  WHERE id = ?
  ```
- No cookie manipulation needed - Lucia handles session persistence automatically
- Cleaner error handling with try/catch and proper error responses
- Aligns with PIM elevation pattern used in `/api/pim/elevate`

**Session Update Logic:**
- **Assuming role**: Sets `assumed_role`, `assumed_at`, `assumed_until` (60min TTL)
- **Clearing role**: Sets all three fields to `NULL`
- Audit logging continues to work via `insertAdminAssumedRoleAudit`

## Key Technical Details

- **Session object** retains `ExtendedSession` type with PIM attributes
- **User object** provides `email`, `role`, `status` from Lucia
- **CSRF validation** continues using `verifyCsrfToken(session, token)`
- **Effective role** continues using `getEffectiveRole(session)` for admin checks
- **Assumed role tracking** now stored directly in D1 `sessions` table

## Testing

- ✅ All 393 files pass TypeScript compilation (`npx astro check`)
- ✅ No remaining `getSessionFromCookie` calls in admin endpoints
- ✅ Session updates persist correctly in D1 `sessions` table
- ✅ Audit logging verified for role assumption/clearing

## Impact

- **Fixes:** Potential 401 Unauthorized errors in admin endpoints
- **Removes:** Last dependencies on legacy session cookie management in admin subsystem
- **Aligns:** Admin role assumption with PIM elevation pattern
- **Progress:** 21 of 42 endpoints migrated (18 ARB + 3 Admin)
- **Remaining:** 21 endpoints still need migration (tracked in #240)

## Security Notes

- Role assumption still restricted to admin and arb_board users only
- CSRF protection maintained via token validation
- Origin verification continues to block cross-origin requests
- Audit trail preserved with enhanced error handling
- Session TTL for assumed roles remains 60 minutes

## Related Issues

Part of #240 - Admin endpoints portion complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)