### PR TITLE
fix: Enable password setup invites for directory-only users

### DIFF
--- a/src/pages/api/admin/send-user-invite.ts
+++ b/src/pages/api/admin/send-user-invite.ts
@@ -1,0 +1,214 @@
+/**
+ * POST /api/admin/send-user-invite
+ *
+ * Send password setup invitation to directory-only users or resend to pending users.
+ * Board/Admin only.
+ *
+ * Flow:
+ * 1. Verify board/admin role
+ * 2. Check if user exists in directory (owners table)
+ * 3. Create user account if doesn't exist (status: pending_setup)
+ * 4. Generate setup token
+ * 5. Send setup email
+ * 6. Return success
+ *
+ * Request body:
+ * {
+ *   "email": "user@example.com",
+ *   "csrf_token": "..."
+ * }
+ *
+ * Response:
+ * - 200: Invite sent successfully
+ * - 400: Invalid request
+ * - 403: Forbidden (not board/admin)
+ * - 404: Email not found in directory
+ * - 500: Server error
+ */
+
+import type { APIRoute } from 'astro';
+import { verifyCsrfToken, getEffectiveRole, isBoardOnly } from '../../../lib/auth';
+import { generateSetupToken, sendSetupEmail, resendSetupToken } from '../../../lib/auth/setup-tokens';
+import { getResendClient } from '../../../lib/resend-client';
+import { logSecurityEvent } from '../../../lib/audit-log';
+import crypto from 'node:crypto';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const db = locals.runtime.env.DB;
+  const user = locals.user;
+  const session = locals.session;
+  const resend = getResendClient(locals.runtime.env);
+  const ipAddress = request.headers.get('cf-connecting-ip') || 'unknown';
+
+  // 1. Auth check
+  if (!session || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const effectiveRole = getEffectiveRole(session);
+  const isAuthorized = isBoardOnly(effectiveRole) || effectiveRole === 'admin';
+
+  if (!isAuthorized) {
+    return new Response(JSON.stringify({ error: 'Forbidden - Board/Admin only' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // 2. Parse request
+  let body: { email?: string; csrf_token?: string; csrfToken?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // 3. CSRF check
+  if (!verifyCsrfToken(session, body.csrf_token ?? body.csrfToken)) {
+    return new Response(JSON.stringify({ error: 'Invalid security token. Please refresh the page.' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const targetEmail = body.email?.trim()?.toLowerCase();
+  if (!targetEmail) {
+    return new Response(JSON.stringify({ error: 'Email is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    // 4. Check if email exists in directory
+    const directoryEntry = await db
+      .prepare('SELECT email, name FROM owners WHERE email = ?')
+      .bind(targetEmail)
+      .first<{ email: string; name: string | null }>();
+
+    if (!directoryEntry) {
+      return new Response(JSON.stringify({ error: 'Email not found in directory' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 5. Check if user account already exists
+    const existingUser = await db
+      .prepare('SELECT email, status FROM users WHERE email = ?')
+      .bind(targetEmail)
+      .first<{ email: string; status: string }>();
+
+    let token: string;
+    let isNewAccount = false;
+
+    if (!existingUser) {
+      // Create new user account with pending_setup status
+      // Get role from KV or default to member
+      let role = 'member';
+      const kv = locals.runtime?.env?.KV as KVNamespace | undefined;
+      if (kv) {
+        const kvRole = await kv.get(targetEmail);
+        if (kvRole && ['member', 'board', 'arb', 'arb_board', 'admin'].includes(kvRole)) {
+          role = kvRole;
+        }
+      }
+
+      const userId = crypto.randomBytes(16).toString('hex');
+      await db
+        .prepare(
+          `INSERT INTO users (id, email, name, role, status, created_at)
+           VALUES (?, ?, ?, ?, 'pending_setup', datetime('now'))`
+        )
+        .bind(userId, targetEmail, directoryEntry.name, role)
+        .run();
+
+      isNewAccount = true;
+
+      await logSecurityEvent(db, {
+        eventType: 'user_account_created_for_invite',
+        severity: 'info',
+        userId: targetEmail,
+        details: {
+          created_by: user.email,
+          role,
+          ip_address: ipAddress,
+        },
+      });
+
+      // Generate setup token
+      const result = await generateSetupToken(db, targetEmail, user.email);
+      token = result.token;
+    } else if (existingUser.status === 'pending_setup') {
+      // Account exists but hasn't set up password - resend invite
+      const result = await resendSetupToken(db, targetEmail, user.email);
+      token = result.token;
+    } else if (existingUser.status === 'active') {
+      return new Response(
+        JSON.stringify({ error: 'User already has an active account' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    } else {
+      return new Response(
+        JSON.stringify({ error: `Cannot send invite to ${existingUser.status} account` }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // 6. Send setup email
+    if (!resend) {
+      return new Response(
+        JSON.stringify({ error: 'Email service not configured' }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const siteUrl = new URL(request.url).origin;
+    await sendSetupEmail(resend, targetEmail, token, directoryEntry.name || undefined, siteUrl);
+
+    await logSecurityEvent(db, {
+      eventType: isNewAccount ? 'user_invite_sent' : 'user_invite_resent',
+      severity: 'info',
+      userId: targetEmail,
+      details: {
+        sent_by: user.email,
+        ip_address: ipAddress,
+      },
+    });
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: isNewAccount ? 'Invite sent successfully' : 'Invite resent successfully',
+        isNewAccount,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Send invite error:', error);
+
+    await logSecurityEvent(db, {
+      eventType: 'user_invite_failed',
+      severity: 'critical',
+      details: {
+        email: targetEmail,
+        sent_by: user.email,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        ip_address: ipAddress,
+      },
+    });
+
+    return new Response(
+      JSON.stringify({ error: 'Failed to send invite. Please try again.' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+};

--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -31,6 +31,7 @@ import type { APIRoute } from 'astro';
 import { checkRateLimit } from '../../../lib/rate-limit';
 import { logSecurityEvent } from '../../../lib/audit-log';
 import { generateResetToken, sendResetEmail } from '../../../lib/auth/reset-tokens';
+import { generateSetupToken, sendSetupEmail } from '../../../lib/auth/setup-tokens';
 import { getResendClient } from '../../../lib/resend-client';
 import crypto from 'node:crypto';
 
@@ -214,7 +215,44 @@ export const POST: APIRoute = async ({ request, locals }) => {
       }
     }
 
-    // 4. Check if user account is active
+    // 4. Check if user account is active or pending setup
+    // Active users get reset emails, pending_setup users get setup emails
+    if (user.status === 'pending_setup') {
+      // User has account but hasn't set up password yet - send setup email
+      const { token } = await generateSetupToken(db, user.email, 'forgot-password-auto');
+
+      if (resend) {
+        try {
+          const siteUrl = new URL(request.url).origin;
+          await sendSetupEmail(resend, user.email, token, user.name || undefined, siteUrl);
+
+          await logSecurityEvent(db, {
+            eventType: 'forgot_password_setup_email_sent',
+            severity: 'info',
+            userId: user.email,
+            details: {
+              status: 'pending_setup',
+              ip_address: ipAddress,
+              user_agent: userAgent,
+            },
+          });
+        } catch (emailError) {
+          console.error('Failed to send setup email:', emailError);
+          await logSecurityEvent(db, {
+            eventType: 'forgot_password_setup_email_failed',
+            severity: 'critical',
+            userId: user.email,
+            details: {
+              error: emailError instanceof Error ? emailError.message : 'Unknown error',
+              ip_address: ipAddress,
+            },
+          });
+        }
+      }
+
+      return genericSuccessResponse;
+    }
+
     // Only send reset emails to active accounts
     if (user.status !== 'active') {
       await logSecurityEvent(db, {

--- a/src/pages/board/members.astro
+++ b/src/pages/board/members.astro
@@ -412,8 +412,9 @@ const csrfToken = session?.csrfToken ?? '';
       <ul class="text-sm text-blue-800 space-y-1 list-disc list-inside">
         <li><strong>Complete Records:</strong> Members with both account + directory entry</li>
         <li><strong>Account Only:</strong> Can log in but not in member directory (admins, service providers)</li>
-        <li><strong>Directory Only:</strong> In directory but haven't set up portal access yet</li>
-        <li><strong>Self-Service:</strong> Members can use "Forgot Password" to create accounts themselves</li>
+        <li><strong>Directory Only:</strong> In directory but haven't set up portal access yet - click "📧 Send Invite" to invite them</li>
+        <li><strong>Pending Setup:</strong> Invitation sent but password not yet created - click "🔄 Resend Invite" if needed</li>
+        <li><strong>Self-Service:</strong> Members can also use "Forgot Password" to create accounts themselves</li>
       </ul>
     </div>
   </PortalPage>
@@ -520,6 +521,25 @@ const csrfToken = session?.csrfToken ?? '';
                 <td class="px-4 py-3 text-sm text-gray-600">${m.address || '-'}</td>
                 <td class="px-4 py-3 text-sm">
                   <div class="flex gap-3">
+                    ${
+                      !m.hasAccount && m.inDirectory
+                        ? `<button
+                      class="text-blue-600 hover:text-blue-800 font-medium"
+                      onclick="sendInvite('${m.email}')"
+                      title="Send password setup invitation"
+                    >
+                      📧 Send Invite
+                    </button>`
+                        : m.hasAccount && m.accountStatus === 'pending_setup'
+                        ? `<button
+                      class="text-amber-600 hover:text-amber-800 font-medium"
+                      onclick="sendInvite('${m.email}')"
+                      title="Resend password setup invitation"
+                    >
+                      🔄 Resend Invite
+                    </button>`
+                        : ''
+                    }
                     <button
                       class="text-clr-green hover:text-clr-green/80 font-medium"
                       onclick="editMember('${m.email}')"
@@ -697,6 +717,37 @@ const csrfToken = session?.csrfToken ?? '';
       }
     } catch (error) {
       console.error('[MEMBERS] Delete error:', error);
+      showMessage('Network error. Please try again.', true);
+    }
+  };
+
+  // Send invite function (global so onclick can call it)
+  window.sendInvite = async function (email) {
+    const confirmed = confirm(`Send password setup invitation to ${email}?\n\nThey will receive an email with a link to create their portal password.`);
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/admin/send-user-invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          csrf_token: CSRF_TOKEN,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message || 'Invitation sent successfully! They will receive an email shortly.');
+        loadMembers(); // Refresh to show updated status (pending_setup)
+      } else {
+        showMessage(result.error || 'Failed to send invitation', true);
+      }
+    } catch (error) {
+      console.error('[MEMBERS] Send invite error:', error);
       showMessage('Network error. Please try again.', true);
     }
   };


### PR DESCRIPTION
## Summary
Fixes the issue where directory-only users never received password setup emails, and adds board UI to send/resend invitations.

## Problem
When directory-only users tried to use "Forgot Password":
1. ✅ System found them in `owners` table
2. ✅ Auto-created user account with `status = 'pending_setup'`
3. ❌ **Didn't send email** because account wasn't `'active'`
4. User saw success message but got no email

## Solution - Part 1: Fix Forgot Password Flow

**File**: `src/pages/api/auth/forgot-password.ts`

- Import `generateSetupToken` and `sendSetupEmail` from setup-tokens
- Check for `pending_setup` status before checking for `active`
- Send **setup email** (not reset email) to pending_setup users
- Log as `forgot_password_setup_email_sent` event
- Users can now successfully self-service via forgot password

## Solution - Part 2: Board Invite UI

**New file**: `src/pages/api/admin/send-user-invite.ts`
- Board/Admin endpoint to send password setup invitations
- Auto-creates user account from directory if doesn't exist
- Generates 48-hour setup token and sends email
- Handles both new invites and resends

**Updated**: `src/pages/board/members.astro`
- Added "📧 Send Invite" button for directory-only users
- Added "🔄 Resend Invite" button for pending_setup users
- JavaScript function to call new API endpoint
- Updated help text to explain invite features

## User Flows

### Flow 1: Board Sends Invite (New)
1. Board views `/board/members`
2. Sees "Directory Only" user
3. Clicks "📧 Send Invite"
4. System creates account with `status='pending_setup'`
5. User receives email with setup link
6. Status changes to "Pending Setup" with "🔄 Resend Invite" option

### Flow 2: Member Uses Forgot Password (Fixed)
1. Directory-only member goes to `/auth/forgot-password`
2. Enters their email
3. System auto-creates account with `status='pending_setup'`
4. **Now sends setup email** (was broken before)
5. Member receives email and sets up password

### Flow 3: Resend Invite
1. Board sees "Pending Setup" user
2. Clicks "🔄 Resend Invite"
3. Old token invalidated, new token created
4. Fresh setup email sent

## Testing
After deploying:
1. Add a directory-only user (in owners, not in users)
2. Click "Send Invite" → Verify email received
3. Have directory user try "Forgot Password" → Verify email received  
4. Click "Resend Invite" on pending user → Verify new email received
5. Complete password setup → User becomes "Active"

## Security
- Board/Admin role required for `/api/admin/send-user-invite`
- CSRF token validation
- Rate limiting inherited from setup-tokens library
- Tokens are cryptographically random (32 bytes)
- Tokens expire after 48 hours
- Single-use tokens
- All actions logged to security_events

🤖 Generated with [Claude Code](https://claude.com/claude-code)