### PR TITLE
fix: Define CSRF_TOKEN constant in members page JavaScript

### DIFF
--- a/src/pages/board/members.astro
+++ b/src/pages/board/members.astro
@@ -421,6 +421,9 @@ const csrfToken = session?.csrfToken ?? '';
 </PortalLayout>
 
 <script is:inline define:vars={{ csrfToken: sanitizeForScriptInjection(csrfToken) }}>
+  // Make CSRF token available to all functions
+  const CSRF_TOKEN = csrfToken;
+
   const msgEl = document.getElementById('members-message');
   const loadingEl = document.getElementById('members-loading');
   const containerEl = document.getElementById('members-container');


### PR DESCRIPTION
Quick fix for ReferenceError when deleting members.

## Problem


## Solution
Added  at top of script block.

The  variable is already available via , but delete/invite functions reference it as .

🤖 Generated with [Claude Code](https://claude.com/claude-code)