### PR TITLE
fix: Add session validation for general API routes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -267,6 +267,22 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     }
   }
 
+  // General API routes: validate session if present and set context.locals
+  // This catches API routes not handled by specific cases above (e.g., /api/log-phone-view)
+  if (pathname.startsWith('/api/') && env?.DB) {
+    if (context.cookies.has(SESSION_COOKIE_NAME)) {
+      const sessionId = getSessionId(context);
+      const { session, user } = await validateSession(env.DB, sessionId, context.url.hostname);
+
+      if (session && user) {
+        // Store user and session in context for API handlers
+        context.locals.user = user;
+        context.locals.session = session;
+      }
+      // Note: We don't return 401 here - let the endpoint decide if auth is required
+    }
+  }
+
   // Portal: require session for all routes except login (which redirects to /auth/login)
   if (pathname.startsWith('/portal')) {
     // Legacy /portal/login redirect to new /auth/login


### PR DESCRIPTION
Fixes 401 Unauthorized errors on directory reveal function.

## Problem
```
POST /api/log-phone-view 401 (Unauthorized)
```

## Root Cause
Middleware had specific handlers for:
- Elevated APIs (`/api/admin`, `/api/board`, etc.)
- Portal routes (`/portal/*`)
- Auth routes (`/auth/*`)

But **no catch-all** for general authenticated API routes like `/api/log-phone-view`.

Result: `context.locals.user` and `context.locals.session` were never set, causing endpoints to see no session and return 401.

## Solution
Added general API handler before portal routes:
- Checks if path starts with `/api/`
- If session cookie present, validates it
- Sets `context.locals.user` and `context.locals.session`
- Doesn't block - lets endpoint decide if auth required

## Testing
After deploying:
1. Go to `/portal/directory`
2. Click "Reveal" on any phone/email
3. Should work for both elevated and regular users
4. No more 401 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)