### PR TITLE
debug: Add logging to origin verification for directory reveal

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -574,15 +574,25 @@ export function verifyOrigin(
   referer: string | null,
   expectedOrigin: string
 ): boolean {
-  if (!origin && !referer) return false;
+  if (!origin && !referer) {
+    console.log('[verifyOrigin] No origin or referer provided');
+    return false;
+  }
 
   // Check Origin header first (more reliable)
   if (origin) {
     try {
       const originUrl = new URL(origin);
       const expectedUrl = new URL(expectedOrigin);
-      return originUrl.origin === expectedUrl.origin;
-    } catch {
+      const match = originUrl.origin === expectedUrl.origin;
+      console.log('[verifyOrigin] Comparing origins:', {
+        origin: originUrl.origin,
+        expected: expectedUrl.origin,
+        match,
+      });
+      return match;
+    } catch (err) {
+      console.error('[verifyOrigin] Error parsing origin:', err);
       return false;
     }
   }
@@ -592,8 +602,15 @@ export function verifyOrigin(
     try {
       const refererUrl = new URL(referer);
       const expectedUrl = new URL(expectedOrigin);
-      return refererUrl.origin === expectedUrl.origin;
-    } catch {
+      const match = refererUrl.origin === expectedUrl.origin;
+      console.log('[verifyOrigin] Comparing referer:', {
+        referer: refererUrl.origin,
+        expected: expectedUrl.origin,
+        match,
+      });
+      return match;
+    } catch (err) {
+      console.error('[verifyOrigin] Error parsing referer:', err);
       return false;
     }
   }

--- a/src/pages/api/log-phone-view.astro
+++ b/src/pages/api/log-phone-view.astro
@@ -29,7 +29,17 @@ if (!session || !user) {
 const origin = Astro.request.headers.get('origin');
 const referer = Astro.request.headers.get('referer');
 const expectedOrigin = Astro.url.origin;
+
+// Debug logging for origin verification
+console.log('[LOG-PHONE-VIEW] Origin verification:', {
+  origin,
+  referer,
+  expectedOrigin,
+  astroUrlHref: Astro.url.href,
+});
+
 if (!verifyOrigin(origin, referer, expectedOrigin)) {
+  console.error('[LOG-PHONE-VIEW] Origin verification FAILED');
   return new Response(JSON.stringify({ error: 'Invalid origin. Request blocked for security.' }), {
     status: 403,
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
Add console logging to debug 403 Forbidden error when clicking reveal in directory.

## Changes
- Added logging to `verifyOrigin()` function to show origin/referer vs expected comparison
- Added logging to `/api/log-phone-view` endpoint before origin check
- Logs will appear in Cloudflare console to identify root cause of 403 error

## Debugging
This will help identify whether the 403 is from:
1. Origin verification failing (origin/referer mismatch)
2. CSRF token validation failing
3. User opted out of sharing contact

Once we see the logs, we can identify the exact cause and fix it properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)