### PR TITLE
fix: Use ExtendedSession CSRF token in portal context

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -574,25 +574,15 @@ export function verifyOrigin(
   referer: string | null,
   expectedOrigin: string
 ): boolean {
-  if (!origin && !referer) {
-    console.log('[verifyOrigin] No origin or referer provided');
-    return false;
-  }
+  if (!origin && !referer) return false;
 
   // Check Origin header first (more reliable)
   if (origin) {
     try {
       const originUrl = new URL(origin);
       const expectedUrl = new URL(expectedOrigin);
-      const match = originUrl.origin === expectedUrl.origin;
-      console.log('[verifyOrigin] Comparing origins:', {
-        origin: originUrl.origin,
-        expected: expectedUrl.origin,
-        match,
-      });
-      return match;
-    } catch (err) {
-      console.error('[verifyOrigin] Error parsing origin:', err);
+      return originUrl.origin === expectedUrl.origin;
+    } catch {
       return false;
     }
   }
@@ -602,15 +592,8 @@ export function verifyOrigin(
     try {
       const refererUrl = new URL(referer);
       const expectedUrl = new URL(expectedOrigin);
-      const match = refererUrl.origin === expectedUrl.origin;
-      console.log('[verifyOrigin] Comparing referer:', {
-        referer: refererUrl.origin,
-        expected: expectedUrl.origin,
-        match,
-      });
-      return match;
-    } catch (err) {
-      console.error('[verifyOrigin] Error parsing referer:', err);
+      return refererUrl.origin === expectedUrl.origin;
+    } catch {
       return false;
     }
   }

--- a/src/lib/portal-context.ts
+++ b/src/lib/portal-context.ts
@@ -85,7 +85,7 @@ export async function getPortalContext(
         exp: Math.floor(luciaSession.expiresAt.getTime() / 1000), // Convert Date to Unix timestamp in seconds
         elevated_until: (luciaSession as any).elevated_until,
         sessionId: luciaSession.id,
-        csrfToken: luciaSession.id, // Use session ID as CSRF token for Lucia sessions
+        csrfToken: (luciaSession as any).csrfToken, // Use the CSRF token from ExtendedSession (set by middleware)
         createdAt: (luciaSession as any).created_at,
         fingerprint: (luciaSession as any).fingerprint,
       };

--- a/src/pages/api/log-phone-view.astro
+++ b/src/pages/api/log-phone-view.astro
@@ -29,17 +29,7 @@ if (!session || !user) {
 const origin = Astro.request.headers.get('origin');
 const referer = Astro.request.headers.get('referer');
 const expectedOrigin = Astro.url.origin;
-
-// Debug logging for origin verification
-console.log('[LOG-PHONE-VIEW] Origin verification:', {
-  origin,
-  referer,
-  expectedOrigin,
-  astroUrlHref: Astro.url.href,
-});
-
 if (!verifyOrigin(origin, referer, expectedOrigin)) {
-  console.error('[LOG-PHONE-VIEW] Origin verification FAILED');
   return new Response(JSON.stringify({ error: 'Invalid origin. Request blocked for security.' }), {
     status: 403,
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
Fixes 403 "Invalid security token" error when clicking reveal in directory.

## Root Cause
CSRF token mismatch between what the directory page sends and what the API endpoint expects:
- **Middleware** generates CSRF token as `hash(sessionId + 'csrf-salt')` and stores it in ExtendedSession
- **Portal context** was overriding this with raw `sessionId`
- **Directory page** sent the raw sessionId as CSRF token
- **API endpoint** compared it against the hashed version from middleware → mismatch → 403

## Changes
- Updated `portal-context.ts` to use the CSRF token from ExtendedSession (set by middleware) instead of overriding it with the raw session ID
- Removed debug logging that was added in PR #250 to diagnose the issue

## Testing
After this fix, clicking "reveal" on directory entries should work without CSRF token errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)