### PR TITLE
feat: Convert all remaining pages to Eastern Time display

### DIFF
--- a/src/components/ArbDashboardCard.astro
+++ b/src/components/ArbDashboardCard.astro
@@ -3,6 +3,7 @@ import type { ArbRequest, ArbFile } from '../lib/arb-db';
 import type { ElectronicSignature } from '../lib/esignature-db';
 import ESignatureDisplay from './ESignatureDisplay.astro';
 import { sanitizeForDisplay } from '../lib/sanitize';
+import { formatEasternDateTime, formatEasternDate } from '../lib/timezone';
 
 interface Props {
   request: ArbRequest;
@@ -82,7 +83,7 @@ function selectedTypes(applicationType: string | null): string[] {
     {req.property_address && <p class="text-sm text-gray-600 mb-1"><strong>Address/Lot:</strong> {sanitizeForDisplay(req.property_address)}</p>}
     <p class="text-gray-700 line-clamp-2" set:html={sanitizeForDisplay(req.description)}></p>
     <div class="flex flex-wrap items-center gap-2 mt-2">
-      <p class="text-xs text-gray-400">Submitted: {new Date(req.created).toLocaleString()}</p>
+      <p class="text-xs text-gray-400">Submitted: {formatEasternDateTime(req.created)}</p>
       {req.review_deadline && (
         <>
           <span class="text-xs text-gray-400">|</span>
@@ -93,7 +94,7 @@ function selectedTypes(applicationType: string | null): string[] {
                 ? 'text-amber-600'
                 : 'text-gray-500'
           }`} data-deadline={req.review_deadline}>
-            Deadline: {new Date(req.review_deadline).toLocaleDateString()}
+            Deadline: {formatEasternDate(req.review_deadline)}
             {new Date(req.review_deadline) < new Date() && ' (OVERDUE)'}
           </p>
         </>
@@ -119,7 +120,7 @@ function selectedTypes(applicationType: string | null): string[] {
         </div>
         <div>
           <label class="block text-sm font-semibold text-gray-500 mb-1">Date of application</label>
-          <div class="w-full rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-gray-600">{new Date(req.created).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+          <div class="w-full rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-gray-600">{formatEasternDate(req.created)}</div>
         </div>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -157,7 +158,7 @@ function selectedTypes(applicationType: string | null): string[] {
         <label class="block text-sm font-semibold text-gray-500 mb-1">Description</label>
         <div class="w-full rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-gray-700 whitespace-pre-wrap min-h-[80px]" set:html={sanitizeForDisplay(req.description)}></div>
       </div>
-      <p class="text-xs text-gray-500">Submitted: {new Date(req.created).toLocaleString()}{req.updated_at ? ` - Last updated: ${new Date(req.updated_at).toLocaleString()}` : ''}</p>
+      <p class="text-xs text-gray-500">Submitted: {formatEasternDateTime(req.created)}{req.updated_at ? ` - Last updated: ${formatEasternDateTime(req.updated_at)}` : ''}</p>
       {req.owner_notes && (
         <div class="mt-3 rounded-lg border border-purple-200 bg-purple-50 p-3">
           <p class="text-xs font-semibold text-purple-900 mb-1">Owner Notes</p>
@@ -229,7 +230,7 @@ function selectedTypes(applicationType: string | null): string[] {
       <>
         {req.review_deadline && new Date(req.review_deadline) < new Date() && (
           <div class="mt-3 rounded-lg border-2 border-red-300 bg-red-50 p-3 no-print">
-            <p class="text-sm font-semibold text-red-900">Warning: Review deadline passed: {new Date(req.review_deadline).toLocaleDateString()}</p>
+            <p class="text-sm font-semibold text-red-900">Warning: Review deadline passed: {formatEasternDate(req.review_deadline)}</p>
           </div>
         )}
         {canApproveArb && (
@@ -264,7 +265,7 @@ function selectedTypes(applicationType: string | null): string[] {
     <div class="space-y-3 text-sm">
       <div class="grid grid-cols-2 gap-4">
         <div><span class="font-semibold text-gray-600">Association:</span> Crooked Lake Reserve</div>
-        <div><span class="font-semibold text-gray-600">Date of application:</span> {new Date(req.created).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+        <div><span class="font-semibold text-gray-600">Date of application:</span> {formatEasternDate(req.created)}</div>
       </div>
       <div class="grid grid-cols-2 gap-4">
         <div><span class="font-semibold text-gray-600">Applicant:</span> {sanitizeForDisplay(req.applicant_name) || '-'}</div>
@@ -277,7 +278,7 @@ function selectedTypes(applicationType: string | null): string[] {
       <div><span class="font-semibold text-gray-600">Application for:</span> {sanitizeForDisplay(req.application_type) || '-'}</div>
       <div><span class="font-semibold text-gray-600">Description:</span></div>
       <div class="whitespace-pre-wrap border border-gray-200 p-3 rounded" set:html={sanitizeForDisplay(req.description)}></div>
-      <div class="text-xs text-gray-500">Submitted: {new Date(req.created).toLocaleString()}</div>
+      <div class="text-xs text-gray-500">Submitted: {formatEasternDateTime(req.created)}</div>
       {files.length > 0 && (
         <div class="print-attachments-section pt-2 border-t">
           <p class="font-semibold">Attachments ({files.length})</p>

--- a/src/components/ESignatureDisplay.astro
+++ b/src/components/ESignatureDisplay.astro
@@ -9,6 +9,7 @@
 
 import type { ElectronicSignature } from '../lib/esignature-db';
 import { parseSignatureData } from '../lib/esignature-db';
+import { formatEasternDateTime } from '../lib/timezone';
 
 interface Props {
   signature: ElectronicSignature | null;
@@ -24,21 +25,6 @@ if (!signature) {
 
 const signatureData = parseSignatureData(signature);
 const isValid = signature.signature_valid === 1 && signature.consent_acknowledged === 1;
-
-function formatDate(dateStr: string): string {
-  try {
-    return new Date(dateStr).toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZoneName: 'short'
-    });
-  } catch {
-    return dateStr;
-  }
-}
 
 function maskIP(ip: string | null): string {
   if (!ip) return 'Not recorded';
@@ -118,7 +104,7 @@ function maskIP(ip: string | null): string {
 
         <div class="flex justify-between">
           <dt class="text-gray-600">Date & Time:</dt>
-          <dd class="font-medium text-gray-700">{formatDate(signature.signed_at)}</dd>
+          <dd class="font-medium text-gray-700">{formatEasternDateTime(signature.signed_at)}</dd>
         </div>
 
         {signatureData && (

--- a/src/components/SearchResults.astro
+++ b/src/components/SearchResults.astro
@@ -2,6 +2,8 @@
 /**
  * Display search results from API (arb, meetings, vendors, owners, feedback_docs, preapproval).
  */
+import { formatEasternDate } from '../lib/timezone';
+
 interface Props {
   arb: { id: string; description: string; application_type: string | null; status: string }[];
   meetings: { id: string; title: string | null; datetime: string }[];
@@ -12,14 +14,6 @@ interface Props {
   query: string;
 }
 const { arb, meetings, vendors, owners, feedback_docs = [], preapproval = [], query } = Astro.props;
-
-function formatDate(s: string): string {
-  try {
-    return new Date(s).toLocaleDateString('en-US', { dateStyle: 'medium' });
-  } catch {
-    return s;
-  }
-}
 ---
 <div class="search-results space-y-6">
   {arb.length > 0 && (
@@ -46,7 +40,7 @@ function formatDate(s: string): string {
           <li>
             <a href="/portal/meetings" class="block p-3 rounded-lg bg-gray-50 hover:bg-gray-100 portal-theme-card border border-gray-100">
               <span class="font-medium text-gray-900 portal-theme-text">{m.title ?? 'Meeting'}</span>
-              <span class="block text-sm text-gray-500 mt-1">{formatDate(m.datetime)}</span>
+              <span class="block text-sm text-gray-500 mt-1">{formatEasternDate(m.datetime)}</span>
             </a>
           </li>
         ))}

--- a/src/components/VotingPanel.astro
+++ b/src/components/VotingPanel.astro
@@ -7,6 +7,7 @@
  * Handles recusal banners and vote submission.
  */
 import type { VoteResolutionResult, ArcRequestVote } from '../lib/arb-voting-db';
+import { formatEasternDateTime } from '../lib/timezone';
 
 interface Props {
   requestId: string;
@@ -145,7 +146,7 @@ const currentVote = myVote?.vote;
           {myVote.comment && (
             <p class="text-sm text-gray-600 mt-2"><strong>Comment:</strong> {myVote.comment}</p>
           )}
-          <p class="text-xs text-gray-400 mt-1">Voted on {new Date(myVote.voted_at).toLocaleString()}</p>
+          <p class="text-xs text-gray-400 mt-1">Voted on {formatEasternDateTime(myVote.voted_at)}</p>
         </div>
         {votingOpen && (
           <span class="text-xs text-blue-600">You can change your vote below</span>

--- a/src/pages/admin/feedback.astro
+++ b/src/pages/admin/feedback.astro
@@ -17,6 +17,7 @@ export const prerender = false;
 import BoardLayout from '../../layouts/BoardLayout.astro';
 import { getAdminContext } from '../../lib/board-context';
 import { listSiteFeedback } from '../../lib/site-feedback-db';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 // Route-level guard: enforce admin-only access
 const ctx = await getAdminContext(Astro);
@@ -69,15 +70,6 @@ const feedback = db
     })
   : [];
 
-function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString();
-  } catch {
-    return s ?? '—';
-  }
-}
 
 const csvParams = new URLSearchParams();
 if (from.trim()) csvParams.set('from', from.trim());

--- a/src/pages/admin/sms-requests.astro
+++ b/src/pages/admin/sms-requests.astro
@@ -17,6 +17,7 @@ export const prerender = false;
 import BoardLayout from '../../layouts/BoardLayout.astro';
 import { getAdminContext } from '../../lib/board-context';
 import { getSmsFeatureRequestCounts, listSmsFeatureRequests } from '../../lib/sms-feature-request-db';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 // Route-level guard: enforce admin-only access
 const ctx = await getAdminContext(Astro);
@@ -51,13 +52,4 @@ const db = env?.DB;
 const counts = db ? await getSmsFeatureRequestCounts(db) : { distinctLots: 0, totalRequests: 0 };
 const requests = db ? await listSmsFeatureRequests(db, pageSize, (page - 1) * pageSize) : [];
 
-function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString();
-  } catch {
-    return s ?? '—';
-  }
-}
 ---

--- a/src/pages/api/arb-export.astro
+++ b/src/pages/api/arb-export.astro
@@ -10,6 +10,7 @@ import { getEffectiveRole } from '../../lib/auth';
 import { listAllArbRequestsFiltered } from '../../lib/arb-db';
 import { escapeHtml } from '../../lib/sanitize';
 import { escapeCsv } from '../../lib/csv-utils';
+import { formatEasternDate } from '../../lib/timezone';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
@@ -38,15 +39,6 @@ const validFormat = format === 'html' ? 'html' : 'csv';
 
 const requests = await listAllArbRequestsFiltered(db, { fromDate: fromDate || null, toDate: toDate || null, status: status || null });
 
-function formatDate(s: string | null | undefined): string {
-  if (!s) return '';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return String(s);
-  }
-}
 
 if (validFormat === 'csv') {
   const headers = ['ID', 'Owner email', 'Applicant', 'Phone', 'Property address', 'Application type', 'Status', 'Created', 'Decision date', 'ARB e-sign'];
@@ -100,7 +92,7 @@ const html = `<!DOCTYPE html>
 </head>
 <body>
   <h1>ARB Requests Report</h1>
-  <p class="meta">Generated ${formatDate(new Date().toISOString())} · Filter: ${escapeHtml(filterDesc)} · ${requests.length} request(s)</p>
+  <p class="meta">Generated ${formatEasternDate(new Date().toISOString())} · Filter: ${escapeHtml(filterDesc)} · ${requests.length} request(s)</p>
   <table>
     <thead>
       <tr>
@@ -124,8 +116,8 @@ ${requests
         <td>${escapeHtml(r.property_address ?? '—')}</td>
         <td>${escapeHtml(r.application_type ?? '—')}</td>
         <td><span class="status ${escapeHtml(r.status)}">${escapeHtml(r.status)}</span></td>
-        <td>${formatDate(r.created)}</td>
-        <td>${formatDate(r.esign_timestamp)}</td>
+        <td>${formatEasternDate(r.created)}</td>
+        <td>${formatEasternDate(r.esign_timestamp)}</td>
         <td class="description">${escapeHtml((r.description ?? '').slice(0, 200))}${(r.description?.length ?? 0) > 200 ? '…' : ''}</td>
       </tr>`
   )

--- a/src/pages/api/arb-upload.astro
+++ b/src/pages/api/arb-upload.astro
@@ -22,6 +22,7 @@ import {
   createElectronicSignature,
   type SignatureData,
 } from '../../lib/esignature-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const MAX_FILE_BYTES = 5 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
@@ -410,7 +411,7 @@ try {
     if (descLower === reqDescLower) {
       return new Response(
         JSON.stringify({
-          error: `Duplicate request detected. You submitted an identical request (${req.id}) on ${new Date(req.created).toLocaleDateString()}. Please check your existing requests or modify this submission.`,
+          error: `Duplicate request detected. You submitted an identical request (${req.id}) on ${formatEasternDate(req.created)}. Please check your existing requests or modify this submission.`,
           duplicateRequestId: req.id,
         }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
@@ -425,7 +426,7 @@ try {
       if (similarity > 0.8) {
         return new Response(
           JSON.stringify({
-            error: `Similar request detected. You submitted a very similar request (${req.id}) on ${new Date(req.created).toLocaleDateString()}. Please review your existing requests or modify this submission to be more distinct.`,
+            error: `Similar request detected. You submitted a very similar request (${req.id}) on ${formatEasternDate(req.created)}. Please review your existing requests or modify this submission to be more distinct.`,
             duplicateRequestId: req.id,
             warning: true,
           }),

--- a/src/pages/auth/forgot-password.astro
+++ b/src/pages/auth/forgot-password.astro
@@ -201,7 +201,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
         } else {
           // Show error message
           if (response.status === 429) {
-            const resetDate = data.resetAt ? new Date(data.resetAt * 1000).toLocaleTimeString() : 'later';
+            const resetDate = data.resetAt ? new Date(data.resetAt * 1000).toLocaleTimeString('en-US', { timeZone: 'America/New_York' }) : 'later';
             showError(`Too many requests. Please try again at ${resetDate}.`);
           } else {
             showError(data.error || 'An error occurred. Please try again.');

--- a/src/pages/board/assessments.astro
+++ b/src/pages/board/assessments.astro
@@ -13,6 +13,7 @@ import {
   isMissingForQuarter,
 } from '../../lib/assessments-db';
 import { escapeHtml } from '../../lib/sanitize';
+import { formatEasternDate } from '../../lib/timezone';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 
@@ -61,12 +62,8 @@ const missingThisQuarter = sortedOwners.filter((o) => {
 });
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '—' : formatted;
 }
 
 function formatCurrency(n: number): string {

--- a/src/pages/board/compliance.astro
+++ b/src/pages/board/compliance.astro
@@ -8,6 +8,7 @@ import { getComplianceStatus } from '../../lib/compliance-db';
 import { getUpcomingMeetingsWithCompliance, formatAdvanceNotice } from '../../lib/meeting-compliance';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
+import { formatEasternDate, formatEasternDateTimeLong } from '../../lib/timezone';
 
 import AdminNav from '../../components/AdminNav.astro';
 const ctx = await getAdminContext(Astro);
@@ -39,12 +40,8 @@ const yearEnd = new Date(now.getFullYear(), 11, 31);
 const daysUntilYearEnd = Math.ceil((yearEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleString(undefined, { dateStyle: 'medium' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '—' : formatted;
 }
 
 function getDocumentYear(doc: any): number {
@@ -163,7 +160,7 @@ function getCategoryLabel(category: string): string {
     <div class="flex items-start justify-between flex-wrap gap-4 mb-4">
       <div>
         <h2 class="text-2xl font-heading font-bold text-clr-green mb-2">Compliance Dashboard</h2>
-        <p class="text-base text-gray-600">Overall compliance score as of {new Date().toLocaleDateString()}</p>
+        <p class="text-base text-gray-600">Overall compliance score as of {formatEasternDate(new Date())}</p>
       </div>
       <div class="text-right">
         <div class="text-5xl font-bold text-clr-green mb-1">{complianceData?.score ?? 0}%</div>
@@ -256,14 +253,7 @@ function getCategoryLabel(category: string): string {
                     )}
                   </div>
                   <div class="text-sm text-gray-600 mb-2">
-                    {meetingDate && meetingDate.toLocaleString('en-US', {
-                      weekday: 'short',
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                      hour: 'numeric',
-                      minute: '2-digit'
-                    })}
+                    {meetingDate && formatEasternDateTimeLong(meetingDate)}
                   </div>
                   <div class="text-sm space-y-1">
                     <div class={status.noticeCompliant ? 'text-green-700' : 'text-amber-800'}>

--- a/src/pages/board/compliance/[requirementId].astro
+++ b/src/pages/board/compliance/[requirementId].astro
@@ -11,6 +11,7 @@ import {
   listComplianceAuditLogs,
   type ComplianceDocument,
 } from '../../../lib/compliance-db';
+import { formatEasternDateTime, formatEasternDate } from '../../../lib/timezone';
 
 const ctx = await getBoardContext(Astro);
 if ('redirect' in ctx) return Astro.redirect(ctx.redirect);
@@ -37,23 +38,6 @@ const currentDocument = allDocuments.find((d) => d.is_current === 1);
 const archivedDocuments = allDocuments.filter((d) => d.is_current === 0);
 const auditLogs = await listComplianceAuditLogs(db, requirementId);
 
-function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return s;
-  }
-}
-
-function formatDateShort(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleString(undefined, { dateStyle: 'medium' });
-  } catch {
-    return s;
-  }
-}
 
 function getDocumentYear(dateStr: string | null): number {
   if (!dateStr) return 0;
@@ -219,7 +203,7 @@ const pageTitle = `${requirement.id}: ${requirement.title}`;
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
             <div class="text-sm text-gray-600 mb-1">Uploaded</div>
-            <div class="text-gray-900">{formatDate(currentDocument.uploaded_at)}</div>
+            <div class="text-gray-900">{formatEasternDateTime(currentDocument.uploaded_at)}</div>
           </div>
           <div>
             <div class="text-sm text-gray-600 mb-1">Uploaded By</div>
@@ -228,7 +212,7 @@ const pageTitle = `${requirement.id}: ${requirement.title}`;
           {currentDocument.document_date && (
             <div>
               <div class="text-sm text-gray-600 mb-1">Document Date</div>
-              <div class="text-gray-900">{formatDateShort(currentDocument.document_date)}</div>
+              <div class="text-gray-900">{formatEasternDate(currentDocument.document_date)}</div>
             </div>
           )}
         </div>
@@ -374,10 +358,10 @@ const pageTitle = `${requirement.id}: ${requirement.title}`;
             {archivedDocuments.map((doc) => (
               <tr class="border-b border-gray-100">
                 <td class="px-4 py-3 text-gray-900">{doc.title}</td>
-                <td class="px-4 py-3 text-gray-600">{formatDate(doc.uploaded_at)}</td>
+                <td class="px-4 py-3 text-gray-600">{formatEasternDateTime(doc.uploaded_at)}</td>
                 <td class="px-4 py-3 text-gray-600">{doc.uploaded_by}</td>
                 <td class="px-4 py-3 text-gray-600">
-                  {formatDateShort(doc.effective_from)} — {formatDateShort(doc.effective_until)}
+                  {formatEasternDate(doc.effective_from)} — {formatEasternDate(doc.effective_until)}
                 </td>
               </tr>
             ))}
@@ -405,7 +389,7 @@ const pageTitle = `${requirement.id}: ${requirement.title}`;
           <tbody>
             {auditLogs.map((log) => (
               <tr class="border-b border-gray-100">
-                <td class="px-4 py-3 text-gray-600 whitespace-nowrap">{formatDate(log.created_at)}</td>
+                <td class="px-4 py-3 text-gray-600 whitespace-nowrap">{formatEasternDateTime(log.created_at)}</td>
                 <td class="px-4 py-3 text-gray-900">{getActionLabel(log.action)}</td>
                 <td class="px-4 py-3 text-gray-600">{log.actor_email}</td>
               </tr>

--- a/src/pages/board/contacts.astro
+++ b/src/pages/board/contacts.astro
@@ -7,6 +7,7 @@ import AdminNav from '../../components/BoardNav.astro';
 import { getAdminContext } from '../../lib/board-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { CONTACT_SUBMISSIONS_EXPIRY_WHERE } from '../../lib/contact-submissions';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 const ctx = await getAdminContext(Astro);
 if ('redirect' in ctx) return Astro.redirect(ctx.redirect);
@@ -41,12 +42,8 @@ const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
 const end = Math.min(page * pageSize, total);
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDateTime(s);
+  return formatted === '—' ? '—' : formatted;
 }
 
 function recipientLabel(r: string): string {

--- a/src/pages/board/feedback.astro
+++ b/src/pages/board/feedback.astro
@@ -6,6 +6,7 @@ import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { isBoardOnly } from '../../lib/auth';
 import { listAllFeedbackDocs, getFeedbackResponseCounts } from '../../lib/feedback-db';
 import { listOwners } from '../../lib/directory-db';
+import { formatEasternDate } from '../../lib/timezone';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 
@@ -57,12 +58,8 @@ const docsWithCounts = db
   : [];
 
 function formatDate(s: string | null): string {
-  if (!s) return '-';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '-' : formatted;
 }
 ---
 

--- a/src/pages/board/maintenance.astro
+++ b/src/pages/board/maintenance.astro
@@ -5,6 +5,7 @@ import { getAdminContext } from '../../lib/board-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { isBoardOnly } from '../../lib/auth';
 import { listAllMaintenance, parsePhotosJson } from '../../lib/maintenance-db';
+import { formatEasternDate } from '../../lib/timezone';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 
@@ -49,11 +50,8 @@ function maintenancePageUrl(value: number): string {
 const allRequests = db ? await listAllMaintenance(db, statusFilter, pageSize, (page - 1) * pageSize) : [];
 
 function formatDate(s: string): string {
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? s : formatted;
 }
 
 function categoryLabel(cat: string): string {

--- a/src/pages/board/member-documents.astro
+++ b/src/pages/board/member-documents.astro
@@ -7,6 +7,7 @@ import { isBoardOnly } from '../../lib/auth';
 import { listMemberDocuments } from '../../lib/member-documents-db';
 import { MEMBER_DOC_CATEGORIES, MEMBER_DOC_CATEGORY_LABELS } from '../../lib/member-documents-db';
 import { sanitizeForScriptInjection } from '../../lib/sanitize';
+import { formatEasternDateTime } from '../../lib/timezone';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 
@@ -48,12 +49,8 @@ const docs = db ? await listMemberDocuments(db, pageSize, (page - 1) * pageSize)
 
 
 function formatDate(s: string | null): string {
-  if (!s) return '-';
-  try {
-    return new Date(s).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDateTime(s);
+  return formatted === '—' ? '-' : formatted;
 }
 
 const docsByCategory = MEMBER_DOC_CATEGORIES.map((cat) => ({

--- a/src/pages/board/news.astro
+++ b/src/pages/board/news.astro
@@ -6,6 +6,7 @@ import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { isBoardOnly } from '../../lib/auth';
 import { listAllNewsItems, getNewsItemImageKeys } from '../../lib/news-items-db';
 import { escapeHtml } from '../../lib/sanitize';
+import { formatEasternDate } from '../../lib/timezone';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 
@@ -47,12 +48,8 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
 const items = db ? await listAllNewsItems(db, pageSize, (page - 1) * pageSize) : [];
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '-' : formatted;
 }
 ---
 

--- a/src/pages/board/public-documents.astro
+++ b/src/pages/board/public-documents.astro
@@ -8,6 +8,7 @@ import { BOARD_ONLY_SLUGS, ARB_FORM_SLUG } from '../../lib/public-documents-db';
 import { sanitizeForScriptInjection } from '../../lib/sanitize';
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 import AdminNav from '../../components/BoardNav.astro';
 const ctx = await getAdminContext(Astro);
@@ -38,12 +39,8 @@ function canEdit(slug: string): boolean {
 }
 
 function formatDate(s: string | null): string {
-  if (!s) return '-';
-  try {
-    return new Date(s).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDateTime(s);
+  return formatted === '—' ? '-' : formatted;
 }
 ---
 

--- a/src/pages/documents.astro
+++ b/src/pages/documents.astro
@@ -4,6 +4,7 @@ export const prerender = false;
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 import { listPublicDocuments } from '../lib/public-documents-db';
+import { formatEasternDate } from '../lib/timezone';
 
 const allDocuments = await getCollection('documents');
 console.log('[DOCUMENTS-PAGE] All documents:', allDocuments.map(d => ({ autoSlug: d.slug, dataSlug: d.data.slug, title: d.data.title, category: d.data.category, published: d.data.published })));
@@ -105,11 +106,7 @@ const keyRules = [
                 <p class="text-clr-gray text-sm font-body mb-4">{doc.data.description}</p>
                 {doc.data.effectiveDate && (
                   <p class="text-gray-500 text-xs font-body mb-4">
-                    Effective: {doc.data.effectiveDate.toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}
+                    Effective: {formatEasternDate(doc.data.effectiveDate.toISOString())}
                   </p>
                 )}
                 <a

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -6,6 +6,7 @@ import { getCollection } from 'astro:content';
 import { listMeetingsForPublicNews } from '../lib/meetings-db';
 import { listPublicNewsItems } from '../lib/news-items-db';
 import { listPublicVendors } from '../lib/vendors-db';
+import { formatEasternDate } from '../lib/timezone';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
@@ -103,7 +104,7 @@ const nextDue = getNextDueDate();
                   <span id="dues-reminder-title">{nextDue.quarter} {nextDue.year} HOA Dues Reminder</span>
                 </h2>
                 <span class="text-sm text-clr-gray whitespace-nowrap font-body" id="dues-reminder-date">
-                  Due {nextDue.dueDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                  Due {formatEasternDate(nextDue.dueDate.toISOString())}
                 </span>
               </div>
               <p class="text-gray-700 mb-3 font-body">
@@ -136,11 +137,7 @@ const nextDue = getNextDueDate();
                   )}
                 </h2>
                 <time class="text-sm text-clr-gray whitespace-nowrap font-body">
-                  {item.date.toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
+                  {formatEasternDate(item.date.toISOString())}
                 </time>
               </div>
               <p class="text-gray-700 mb-3 font-body">{item.summary}</p>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
+import { formatEasternDate } from '../../lib/timezone';
 
 export async function getStaticPaths() {
   const newsItems = await getCollection('news');
@@ -26,11 +27,7 @@ const { Content } = await item.render();
         <h1 class="text-4xl font-heading font-bold text-clr-green mb-4">{item.data.title}</h1>
         <div class="flex items-center text-clr-gray text-sm mb-4 flex-wrap gap-2 font-body">
           <time>
-            {item.data.date.toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+            {formatEasternDate(item.data.date.toISOString())}
           </time>
           {item.data.tags && item.data.tags.length > 0 && (
             <div class="flex flex-wrap gap-2 ml-4">

--- a/src/pages/news/item/[id].astro
+++ b/src/pages/news/item/[id].astro
@@ -3,6 +3,7 @@ export const prerender = false;
 
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { getNewsItemById, getNewsItemImageKeys } from '../../../lib/news-items-db';
+import { formatEasternDate } from '../../../lib/timezone';
 
 const { id } = Astro.params;
 const runtime = Astro.locals.runtime;
@@ -19,13 +20,6 @@ if (!item || item.is_public !== 1) {
 
 const imageKeys = getNewsItemImageKeys(item);
 
-function formatDate(s: string): string {
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
-  } catch {
-    return s;
-  }
-}
 ---
 
 <BaseLayout title={item.title} description={item.body.slice(0, 160)}>
@@ -34,7 +28,7 @@ function formatDate(s: string): string {
       <header class="mb-6">
         <a href="/news" class="text-clr-orange font-semibold hover:underline text-sm font-body mb-4 inline-block">← News</a>
         <h1 class="text-4xl font-heading font-bold text-clr-green mb-4">{item.title}</h1>
-        <time class="text-clr-gray text-sm font-body">{formatDate(item.created_at)}</time>
+        <time class="text-clr-gray text-sm font-body">{formatEasternDate(item.created_at)}</time>
       </header>
       <div class="prose prose-gray max-w-none font-body text-base whitespace-pre-wrap">{item.body}</div>
       {imageKeys.length > 0 && (

--- a/src/pages/news/meeting/[id].astro
+++ b/src/pages/news/meeting/[id].astro
@@ -3,6 +3,7 @@ export const prerender = false;
 
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { getPublicMeetingById } from '../../../lib/meetings-db';
+import { formatEasternDateTimeLong } from '../../../lib/timezone';
 
 const { id } = Astro.params;
 if (!id) {
@@ -18,20 +19,6 @@ if (!meeting) {
   return Astro.redirect('/news');
 }
 
-function formatDateTime(dt: string): string {
-  try {
-    return new Date(dt).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dt;
-  }
-}
 ---
 
 <BaseLayout title={meeting.title ?? 'Meeting'} description={meeting.description ?? undefined}>
@@ -41,7 +28,7 @@ function formatDateTime(dt: string): string {
         <h1 class="text-4xl font-heading font-bold text-clr-green mb-4">{meeting.title ?? 'Meeting'}</h1>
         <div class="text-clr-gray text-sm mb-4 font-body">
           <time datetime={meeting.datetime}>
-            {formatDateTime(meeting.datetime)}
+            {formatEasternDateTimeLong(meeting.datetime)}
           </time>
         </div>
         {meeting.location && (

--- a/src/pages/portal/admin/feedback.astro
+++ b/src/pages/portal/admin/feedback.astro
@@ -7,6 +7,7 @@ import AdminNav from '../../../components/AdminNav.astro';
 import { getAdminContext } from '../../../lib/board-context';
 import { getPortalBadgeCounts } from '../../../lib/portal-badge-counts';
 import { listSiteFeedback } from '../../../lib/site-feedback-db';
+import { formatEasternDateTime } from '../../../lib/timezone';
 
 const ctx = await getAdminContext(Astro);
 if ('redirect' in ctx) return Astro.redirect(ctx.redirect);
@@ -61,15 +62,6 @@ const feedback = db
     })
   : [];
 
-function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString();
-  } catch {
-    return s ?? '—';
-  }
-}
 
 const csvParams = new URLSearchParams();
 if (from.trim()) csvParams.set('from', from.trim());
@@ -170,7 +162,7 @@ const csvHref = `/api/site-feedback?${csvParams.toString()}`;
           <tbody>
             {feedback.map((row) => (
               <tr class="border-b border-gray-100 hover:bg-gray-50/50">
-                <td class="py-2 px-3 text-gray-600 whitespace-nowrap">{formatDate(row.created_at)}</td>
+                <td class="py-2 px-3 text-gray-600 whitespace-nowrap">{formatEasternDateTime(row.created_at)}</td>
                 <td class="py-2 px-3">{row.thumbs === 1 ? '👍' : '👎'}</td>
                 <td class="py-2 px-3 max-w-xs truncate" title={row.url}>{row.url || '—'}</td>
                 <td class="py-2 px-3 text-gray-600">{row.viewport ?? '—'}</td>

--- a/src/pages/portal/admin/sms-requests.astro
+++ b/src/pages/portal/admin/sms-requests.astro
@@ -7,6 +7,7 @@ import AdminNav from '../../../components/AdminNav.astro';
 import { getAdminContext } from '../../../lib/board-context';
 import { getPortalBadgeCounts } from '../../../lib/portal-badge-counts';
 import { getSmsFeatureRequestCounts, listSmsFeatureRequests } from '../../../lib/sms-feature-request-db';
+import { formatEasternDateTime } from '../../../lib/timezone';
 
 const ctx = await getAdminContext(Astro);
 if ('redirect' in ctx) return Astro.redirect(ctx.redirect);
@@ -43,15 +44,6 @@ function adminSmsPageUrl(value: number): string {
 const counts = db ? await getSmsFeatureRequestCounts(db) : { distinctLots: 0, totalRequests: 0 };
 const requests = db ? await listSmsFeatureRequests(db, pageSize, (page - 1) * pageSize) : [];
 
-function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString();
-  } catch {
-    return s ?? '—';
-  }
-}
 ---
 
 <PortalLayout title="SMS Requests | Admin | Member Portal | Crooked Lake Reserve HOA">
@@ -121,7 +113,7 @@ function formatDate(s: string | null): string {
             {requests.map((row) => (
               <tr class="border-b border-gray-100 hover:bg-gray-50/50">
                 <td class="py-2 px-3 font-medium">{row.lot_number}</td>
-                <td class="py-2 px-3 text-gray-600">{formatDate(row.created_at)}</td>
+                <td class="py-2 px-3 text-gray-600">{formatEasternDateTime(row.created_at)}</td>
               </tr>
             ))}
           </tbody>

--- a/src/pages/portal/admin/test-email.astro
+++ b/src/pages/portal/admin/test-email.astro
@@ -143,7 +143,7 @@ const csrfToken = session?.csrfToken ?? '';
         if (first && first.textContent?.includes('No sends yet')) first.remove();
         const div = document.createElement('div');
         div.className = 'border-b border-gray-200 pb-2 last:border-0';
-        const time = new Date().toLocaleString();
+        const time = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
         const ok = entry.ok;
         const timeSpan = document.createElement('span');
         timeSpan.className = 'text-gray-500';
@@ -217,7 +217,7 @@ const csrfToken = session?.csrfToken ?? '';
             const data = await res.json().catch(() => ({}));
             if (res.ok && typeof data === 'object' && data !== null) {
               renderEnvRows(data);
-              envMessage.textContent = 'Updated at ' + new Date().toLocaleTimeString();
+              envMessage.textContent = 'Updated at ' + new Date().toLocaleTimeString('en-US', { timeZone: 'America/New_York' });
               envMessage.classList.remove('hidden');
             } else {
               envMessage.textContent = 'Failed to load (' + (data.error || res.status) + ').';

--- a/src/pages/portal/arb-request.astro
+++ b/src/pages/portal/arb-request.astro
@@ -7,6 +7,7 @@ import FormField from '../../components/FormField.astro';
 import ESignatureCapture from '../../components/ESignatureCapture.astro';
 import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
+import { formatEasternDateTime, formatEasternDate } from '../../lib/timezone';
 import { SESSION_COOKIE_NAME } from '../../lib/auth';
 import { getOwnerByEmail, getPhonesArray } from '../../lib/directory-db';
 import { getPreapprovalById } from '../../lib/preapproval-db';
@@ -149,7 +150,7 @@ const arbInputClass = 'w-full rounded-lg border border-gray-300 px-4 py-3 text-b
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700 mb-1">Date of application</label>
-            <p id="app-date" class="text-gray-600 py-2">{new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</p>
+            <p id="app-date" class="text-gray-600 py-2">{formatEasternDate(new Date().toISOString())}</p>
           </div>
         </div>
 
@@ -389,7 +390,7 @@ const arbInputClass = 'w-full rounded-lg border border-gray-300 px-4 py-3 text-b
         if (diffMins < 1) return 'just now';
         if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
         if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-        return date.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+        return date.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' });
       }
 
       function updateLastSaved(timestamp) {

--- a/src/pages/portal/assessments.astro
+++ b/src/pages/portal/assessments.astro
@@ -7,6 +7,7 @@ import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { getOwnerByEmail, getPrimaryOwnerEmailForAddress } from '../../lib/directory-db';
 import { getAssessmentByOwner, getPaymentHistory, listSpecialAssessmentsByOwner } from '../../lib/assessments-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro, { fingerprint: true });
 if (!session) return Astro.redirect('/auth/login');
@@ -102,21 +103,8 @@ if (!isPaidThrough && assessment?.next_due) {
 }
 
 function formatDate(s: string | null): string {
-  if (!s) return '-';
-  try {
-    // Parse YYYY-MM-DD as local date; otherwise "2026-01-01" is UTC midnight and shows as Dec 31 in US TZ
-    const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(s.trim());
-    if (match) {
-      const year = parseInt(match[1], 10);
-      const month = parseInt(match[2], 10) - 1;
-      const day = parseInt(match[3], 10);
-      const d = new Date(year, month, day);
-      if (!Number.isNaN(d.getTime())) return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-    }
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '-' : formatted;
 }
 
 function formatCurrency(n: number): string {

--- a/src/pages/portal/assessments/receipt/[id].astro
+++ b/src/pages/portal/assessments/receipt/[id].astro
@@ -12,6 +12,7 @@ import { getPortalContext } from '../../../../lib/portal-context';
 import { getOwnerByEmail, getPrimaryOwnerEmailForAddress } from '../../../../lib/directory-db';
 import { getPaymentById } from '../../../../lib/assessments-db';
 import { listArbRequestsByHousehold } from '../../../../lib/arb-db';
+import { formatEasternDate } from '../../../../lib/timezone';
 
 const { id } = Astro.params;
 const { env, session, effectiveRole } = await getPortalContext(Astro);
@@ -76,15 +77,6 @@ const periodsCovered = payment.paid_through_after
   ? getQuartersCovered(payment.paid_through_after)
   : inferQuarterFromPaidAt(payment.paid_at);
 
-function formatDate(s: string | null): string {
-  if (!s) return '—';
-  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(s.trim());
-  if (match) {
-    const d = new Date(parseInt(match[1], 10), parseInt(match[2], 10) - 1, parseInt(match[3], 10));
-    if (!Number.isNaN(d.getTime())) return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
-  }
-  return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
-}
 
 function formatCurrency(n: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n);
@@ -118,7 +110,7 @@ function formatCurrency(n: number): string {
               </>
             )}
             <dt class="font-medium text-gray-700">Payment date</dt>
-            <dd class="text-gray-900">{formatDate(payment.paid_at)}</dd>
+            <dd class="text-gray-900">{formatEasternDate(payment.paid_at)}</dd>
             <dt class="font-medium text-gray-700">Amount paid</dt>
             <dd class="text-gray-900 font-semibold">{formatCurrency(payment.amount)}</dd>
             {payment.payment_method && (
@@ -148,7 +140,7 @@ function formatCurrency(n: number): string {
             <p class="text-sm text-gray-600 mb-3">Quarterly dues are due on the 1st of January, April, July, and October. This payment applies to the following period(s):</p>
             <ul class="list-disc list-inside space-y-1 text-sm text-gray-900">
               {periodsCovered.map((p) => (
-                <li>{p.quarter} {p.year} — due {formatDate(p.dueDate)}</li>
+                <li>{p.quarter} {p.year} — due {formatEasternDate(p.dueDate)}</li>
               ))}
             </ul>
           </section>

--- a/src/pages/portal/compliance.astro
+++ b/src/pages/portal/compliance.astro
@@ -11,6 +11,7 @@ import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { getComplianceStatus } from '../../lib/compliance-db';
 import { listPublicDocuments } from '../../lib/public-documents-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -79,12 +80,8 @@ const groupedStatuses = categories.map((cat) => ({
 })).filter((cat) => cat.items.length > 0);
 
 function formatDate(s: string | null): string {
-  if (!s) return '';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '' : formatted;
 }
 
 function getStatusBadge(status: string): { label: string; class: string } {

--- a/src/pages/portal/documents.astro
+++ b/src/pages/portal/documents.astro
@@ -12,6 +12,7 @@ import { listUpcomingWithCountsAndUser, householdHasRsvpd } from '../../lib/meet
 import { listActiveFeedbackDocs, getFeedbackResponse, householdHasResponded } from '../../lib/feedback-db';
 import { listMemberDocuments } from '../../lib/member-documents-db';
 import { MEMBER_DOC_CATEGORIES, MEMBER_DOC_CATEGORY_LABELS } from '../../lib/member-documents-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -70,12 +71,8 @@ if (db) {
 const docs = db ? await listMemberDocuments(db) : [];
 
 function formatDate(s: string | null): string {
-  if (!s) return '';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '' : formatted;
 }
 
 const docsByCategory = MEMBER_DOC_CATEGORIES.map((cat) => ({

--- a/src/pages/portal/elevation-audit.astro
+++ b/src/pages/portal/elevation-audit.astro
@@ -12,6 +12,7 @@ import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listPimElevationLog } from '../../lib/pim-db';
 import { ELEVATED_ROLES } from '../../lib/auth';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -50,13 +51,7 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
 const pimLog = db ? await listPimElevationLog(db, pageSize, (page - 1) * pageSize) : [];
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString();
-  } catch {
-    return s ?? '—';
-  }
+  return formatEasternDateTime(s);
 }
 ---
 

--- a/src/pages/portal/feedback.astro
+++ b/src/pages/portal/feedback.astro
@@ -6,6 +6,7 @@ import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listActiveFeedbackDocs, getFeedbackResponse, householdHasResponded } from '../../lib/feedback-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro, { fingerprint: true });
 if (!session) return Astro.redirect('/auth/login');
@@ -36,12 +37,8 @@ const docsWithMyResponse = db
   : [];
 
 function formatDate(s: string | null): string {
-  if (!s) return '-';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '-' : formatted;
 }
 ---
 

--- a/src/pages/portal/maintenance.astro
+++ b/src/pages/portal/maintenance.astro
@@ -6,6 +6,7 @@ import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listMaintenanceByHousehold, parsePhotosJson, MAINTENANCE_CATEGORIES } from '../../lib/maintenance-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro, { fingerprint: true });
 if (!session) return Astro.redirect('/auth/login');
@@ -22,11 +23,8 @@ function categoryLabel(cat: string): string {
 }
 
 function formatDate(s: string): string {
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? s : formatted;
 }
 ---
 

--- a/src/pages/portal/my-activity.astro
+++ b/src/pages/portal/my-activity.astro
@@ -8,6 +8,7 @@ import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listDirectoryLogsByViewer } from '../../lib/directory-db';
 import { listArbAuditLogForOwner } from '../../lib/arb-db';
 import { getLastLogonTime, listLoginHistoryByEmail } from '../../lib/login-history-db';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -49,13 +50,8 @@ const loginHistory = db ? await listLoginHistoryByEmail(db, email, pageSize, (lo
 const BLANK = '—';
 
 function formatDate(s: string | null): string {
-  if (!s) return BLANK;
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return s ?? BLANK;
-  }
+  const formatted = formatEasternDateTime(s);
+  return formatted === '—' ? BLANK : formatted;
 }
 
 function formatLoginTime(s: string | null): string {

--- a/src/pages/portal/my-requests.astro
+++ b/src/pages/portal/my-requests.astro
@@ -11,6 +11,7 @@ import type { ArbFile } from '../../lib/arb-db';
 import { batchLoadElectronicSignatures } from '../../lib/esignature-db';
 import type { ElectronicSignature } from '../../lib/esignature-db';
 import { sanitizeForDisplay } from '../../lib/sanitize';
+import { formatEasternDate, formatEasternDateTime } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro, { fingerprint: true });
 if (!session) return Astro.redirect('/auth/login');
@@ -77,7 +78,8 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
   if (status !== 'approved' && status !== 'rejected') return null;
   const by = parts[1] ?? arbEsign;
   const dateStr = esignTimestamp ?? parts[3];
-  const date = dateStr ? new Date(dateStr).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) : '';
+  const formatted = formatEasternDate(dateStr);
+  const date = formatted !== '—' ? formatted : '';
   return { status, by, date };
 }
 ---
@@ -172,7 +174,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                             </span>
                           </div>
                           <p class="text-gray-700 text-base line-clamp-2 leading-relaxed" set:html={sanitizeForDisplay(req.description)}></p>
-                          <p class="text-sm text-gray-500 mt-2">Submitted: {new Date(req.created).toLocaleString()}</p>
+                          <p class="text-sm text-gray-500 mt-2">Submitted: {formatEasternDateTime(req.created)}</p>
                         </div>
                         <span class="request-chevron text-gray-400 shrink-0 ml-2 text-xl" aria-hidden="true">&#9660;</span>
                       </button>
@@ -205,7 +207,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                         </span>
                       </div>
                       <p class="text-gray-700 text-base line-clamp-2 leading-relaxed" set:html={sanitizeForDisplay(req.description)}></p>
-                      <p class="text-sm text-gray-500 mt-2">Submitted: {new Date(req.created).toLocaleString()}</p>
+                      <p class="text-sm text-gray-500 mt-2">Submitted: {formatEasternDateTime(req.created)}</p>
                     </div>
                     <span class="request-chevron text-gray-400 shrink-0 ml-2 text-xl" aria-hidden="true">&#9660;</span>
                   </button>
@@ -229,7 +231,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                         </div>
                         <div>
                           <label class="block text-sm font-semibold text-gray-500 mb-1">Date of application</label>
-                          <div class="w-full rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-gray-600 cursor-not-allowed">{new Date(req.created).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+                          <div class="w-full rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-gray-600 cursor-not-allowed">{formatEasternDate(req.created)}</div>
                         </div>
                       </div>
                       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -267,7 +269,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                         <label class="block text-sm font-semibold text-gray-500 mb-1">Description of changes</label>
                         <div class="w-full rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-gray-700 whitespace-pre-wrap cursor-not-allowed min-h-[100px]" set:html={sanitizeForDisplay(req.description)}></div>
                       </div>
-                      <p class="text-xs text-gray-500">Submitted: {new Date(req.created).toLocaleString()}{req.updated_at ? ` - Last updated: ${new Date(req.updated_at).toLocaleString()}` : ''}</p>
+                      <p class="text-xs text-gray-500">Submitted: {formatEasternDateTime(req.created)}{req.updated_at ? ` - Last updated: ${formatEasternDateTime(req.updated_at)}` : ''}</p>
                       {req.owner_notes && (
                         <div class="mt-3 rounded-lg border border-purple-200 bg-purple-50 p-3">
                           <p class="text-xs font-semibold text-purple-900 mb-1">Your Notes</p>
@@ -320,7 +322,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                       <div class="no-print pt-6 space-y-4">
                         {req.updated_at && req.updated_at !== req.created && (
                           <p class="text-sm text-gray-500">
-                            Last saved: {new Date(req.updated_at).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}
+                            Last saved: {formatEasternDateTime(req.updated_at)}
                           </p>
                         )}
                         <div class="flex flex-wrap gap-4 items-center">
@@ -357,7 +359,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                     <div class="space-y-3 text-sm">
                       <div class="grid grid-cols-2 gap-4">
                         <div><span class="font-semibold text-gray-600">Association:</span> Crooked Lake Reserve</div>
-                        <div><span class="font-semibold text-gray-600">Date of application:</span> {new Date(req.created).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+                        <div><span class="font-semibold text-gray-600">Date of application:</span> {formatEasternDate(req.created)}</div>
                       </div>
                       <div class="grid grid-cols-2 gap-4">
                         <div><span class="font-semibold text-gray-600">Applicant:</span> {sanitizeForDisplay(req.applicant_name) || '-'}</div>
@@ -370,7 +372,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
                       <div><span class="font-semibold text-gray-600">Application for:</span> {sanitizeForDisplay(req.application_type) || '-'}</div>
                       <div><span class="font-semibold text-gray-600">Description:</span></div>
                       <div class="whitespace-pre-wrap border border-gray-200 p-3 rounded" set:html={sanitizeForDisplay(req.description)}></div>
-                      <div class="text-xs text-gray-500">Submitted: {new Date(req.created).toLocaleString()}</div>
+                      <div class="text-xs text-gray-500">Submitted: {formatEasternDateTime(req.created)}</div>
                       {files.length > 0 && (
                         <div class="print-attachments-section pt-2 border-t">
                           <p class="font-semibold">Attachments ({files.length})</p>

--- a/src/pages/portal/news.astro
+++ b/src/pages/portal/news.astro
@@ -6,6 +6,7 @@ import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listPortalNewsItems, getNewsItemImageKeys } from '../../lib/news-items-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -44,12 +45,7 @@ function portalNewsPageUrl(value: number): string {
 const items = db ? await listPortalNewsItems(db, pageSize, (page - 1) * pageSize) : [];
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  return formatEasternDate(s);
 }
 ---
 

--- a/src/pages/portal/profile/security.astro
+++ b/src/pages/portal/profile/security.astro
@@ -16,6 +16,7 @@ import PortalSidebar from '../../../components/PortalSidebar.astro';
 import PortalHeader from '../../../components/PortalHeader.astro';
 import { getPortalContext } from '../../../lib/portal-context';
 import { getOwnerByEmail } from '../../../lib/directory-db';
+import { formatEasternDateTime } from '../../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -53,12 +54,8 @@ if (db && mfaEnabled) {
 
 function formatDate(iso: string | null | undefined): string {
   if (!iso) return 'Never';
-  try {
-    const d = new Date(iso);
-    return Number.isNaN(d.getTime()) ? iso : d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return iso ?? 'Never';
-  }
+  const formatted = formatEasternDateTime(iso);
+  return formatted === '—' ? (iso ?? 'Never') : formatted;
 }
 ---
 

--- a/src/pages/portal/requests.astro
+++ b/src/pages/portal/requests.astro
@@ -8,6 +8,7 @@ import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listArbRequestsByHousehold, listArbAuditLogForRequest, getSubmittedForReviewAt } from '../../lib/arb-db';
 import type { ArbRequest, ArbAuditLogRow } from '../../lib/arb-db';
 import { sanitizeForDisplay } from '../../lib/sanitize';
+import { formatEasternDate, formatEasternDateTime } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro, { fingerprint: true });
 if (!session) return Astro.redirect('/auth/login');
@@ -35,21 +36,13 @@ const draftCount = requests.filter((r) => r.status === 'pending').length;
 const inReviewCount = requests.filter((r) => r.status === 'in_review').length;
 
 function formatDate(s: string | null | undefined): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDate(s);
+  return formatted === '—' ? '—' : formatted;
 }
 
 function formatDateTime(s: string | null | undefined): string {
-  if (!s) return '—';
-  try {
-    return new Date(s).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
-  } catch {
-    return s;
-  }
+  const formatted = formatEasternDateTime(s);
+  return formatted === '—' ? '—' : formatted;
 }
 
 function daysInReview(submittedAt: string | null | undefined): number | null {
@@ -338,7 +331,7 @@ function statusLabel(status: string): string {
         .then(function (data) {
           if (!data || !data.requests) return;
           var el = document.getElementById('requests-last-updated');
-          if (el) el.textContent = 'Updated ' + new Date().toLocaleTimeString();
+          if (el) el.textContent = 'Updated ' + new Date().toLocaleTimeString('en-US', { timeZone: 'America/New_York' });
           window.__requestsData = data;
         })
         .catch(function () {});

--- a/src/pages/portal/usage.astro
+++ b/src/pages/portal/usage.astro
@@ -21,6 +21,7 @@ import AdminNav from '../../components/AdminNav.astro';
 import { getAdminContext } from '../../lib/board-context';
 import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { getDailyStats, getWeeklyStats, getAdminPageViews, getAdminPageViewsCount, getTopPagesByViews } from '../../lib/usage-db';
+import { formatEasternDateTime } from '../../lib/timezone';
 
 // Route-level guard: enforce admin-only access
 const ctx = await getAdminContext(Astro);
@@ -81,13 +82,7 @@ function viewsPageUrl(key: string, value: number): string {
 }
 
 function formatDate(s: string | null): string {
-  if (!s) return '—';
-  try {
-    const d = new Date(s);
-    return Number.isNaN(d.getTime()) ? s : d.toLocaleString();
-  } catch {
-    return s ?? '—';
-  }
+  return formatEasternDateTime(s);
 }
 
 const chartData = { daily, weekly, topPages };

--- a/src/pages/portal/vendors.astro
+++ b/src/pages/portal/vendors.astro
@@ -11,6 +11,7 @@ import { getOwnerByEmail } from '../../lib/directory-db';
 import { listMaintenanceByHousehold } from '../../lib/maintenance-db';
 import { listUpcomingWithCountsAndUser, householdHasRsvpd } from '../../lib/meetings-db';
 import { listActiveFeedbackDocs, getFeedbackResponse, householdHasResponded } from '../../lib/feedback-db';
+import { formatEasternDate } from '../../lib/timezone';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro, { fingerprint: true });
 if (!session) return Astro.redirect('/auth/login');
@@ -225,7 +226,7 @@ function parseFiles(filesJson: string | null): { name: string; key: string }[] {
                     )}
                     {sub.submitted_at && (
                       <p class="text-sm text-gray-400">
-                        {new Date(sub.submitted_at).toLocaleDateString(undefined, { dateStyle: 'medium' })}
+                        {formatEasternDate(sub.submitted_at)}
                       </p>
                     )}
                   </div>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,8 +1,9 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { formatEasternDate } from '../lib/timezone';
 
 const siteURL = Astro.site || 'https://clrhoa.com';
-const currentDate = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+const currentDate = formatEasternDate(new Date().toISOString());
 ---
 
 <BaseLayout title="Privacy Policy" description="Privacy policy for Crooked Lake Reserve HOA website">


### PR DESCRIPTION
## Summary
Completes Issue #163 by converting ALL timestamp displays across the entire site to use Eastern Time (America/New_York timezone) for consistent user experience for Florida-based HOA members.

This PR builds on PR #255, which updated backups, audit logs, and meetings pages.

## Changes
Updated **42 files** across the entire application:

### Portal Pages (15 files)
- **ARB pages**: arb-request, my-requests, requests
- **Assessments**: assessments, receipt page
- **Other**: vendors, feedback, maintenance, documents, compliance, news
- **User pages**: my-activity, profile/security, elevation-audit, usage

### Board Pages (9 files)
- news, assessments, feedback, maintenance, member-documents
- contacts, public-documents, compliance (main + detail)

### Admin Pages (5 files)
- portal/admin: sms-requests, feedback, test-email
- admin: sms-requests, feedback

### Public Pages (4 files)
- News pages (main, slug, item, meeting detail)
- documents, privacy

### Components (4 files)
- ArbDashboardCard, VotingPanel, ESignatureDisplay, SearchResults

### API & Auth (3 files)
- arb-upload, arb-export, forgot-password

## Technical Implementation
All pages now use centralized timezone utilities from `lib/timezone.ts`:
- `formatEasternDateTime()` - datetime fields with timezone (e.g., "Feb 17, 2026, 2:30 PM EST")
- `formatEasternDate()` - date-only fields (e.g., "Feb 17, 2026")
- `formatEasternDateTimeLong()` - detailed timestamps (e.g., "Monday, Feb 17, 2026, 2:30:45 PM EST")

Client-side JavaScript updated to include `{ timeZone: 'America/New_York' }` parameter.

## Impact
- **All dates** displayed in Eastern Time (automatically handles EST/EDT transitions)
- **Consistent UX** for Florida-based HOA members
- **127 insertions, 312 deletions** (net -185 lines from replacing verbose inline formatting)

## Testing
✅ All **512 tests passing**

## Closes
Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)