### PR TITLE
fix: Correct AdminNav placement in contact submissions page

### DIFF
--- a/src/pages/board/contacts.astro
+++ b/src/pages/board/contacts.astro
@@ -70,6 +70,7 @@ function safeMailto(email: string): string {
     vendorPendingCount={badges.vendorPendingCount}
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
+  >
     <AdminNav currentPath="/board/contacts" />
 
     <div class="mb-6">


### PR DESCRIPTION
## Summary
Fixes Issue #148 - broken layout with garbled text on the contact submissions page.

## Problem
The `<AdminNav>` component was incorrectly placed inside the `<PortalPage>` component's props section instead of in the content slot, causing:
- Garbled text display: "Contact submissions Help Public Site M Michael Ginter..."
- Broken page layout
- AdminNav not rendering properly

## Solution
Moved `<AdminNav currentPath="/board/contacts" />` from inside the PortalPage props to the content slot by adding the closing `>` before the AdminNav component.

**Before:**
```astro
  <PortalPage
    ...props...
    <AdminNav currentPath="/board/contacts" />
```

**After:**
```astro
  <PortalPage
    ...props...
  >
    <AdminNav currentPath="/board/contacts" />
```

This matches the correct pattern used in all other board pages (news, assessments, etc.).

## Testing
✅ Build completes successfully
✅ Page now has clean admin layout with proper header and navigation

## Closes
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)