### PR TITLE
feat: Hide pre-approval library from members when empty

### DIFF
--- a/src/components/PortalPage.astro
+++ b/src/components/PortalPage.astro
@@ -23,6 +23,7 @@ interface Props {
   maintenanceOpenCount?: number;
   meetingsRsvpCount?: number;
   feedbackDueCount?: number;
+  libraryItemCount?: number;
   elevatedUntil?: number | null;
 }
 
@@ -40,6 +41,7 @@ const {
   maintenanceOpenCount = 0,
   meetingsRsvpCount = 0,
   feedbackDueCount = 0,
+  libraryItemCount = 0,
   elevatedUntil = null,
 } = Astro.props;
 
@@ -73,6 +75,7 @@ const showPimBanner = actualElevatedUntil && actualElevatedUntil > now;
     maintenanceOpenCount={maintenanceOpenCount}
     meetingsRsvpCount={meetingsRsvpCount}
     feedbackDueCount={feedbackDueCount}
+    libraryItemCount={libraryItemCount}
   />
 
   <!-- Main Content Area -->

--- a/src/components/PortalSidebar.astro
+++ b/src/components/PortalSidebar.astro
@@ -16,6 +16,7 @@ interface Props {
   maintenanceOpenCount?: number;
   meetingsRsvpCount?: number;
   feedbackDueCount?: number;
+  libraryItemCount?: number;
 }
 
 const {
@@ -28,12 +29,14 @@ const {
   maintenanceOpenCount = 0,
   meetingsRsvpCount = 0,
   feedbackDueCount = 0,
+  libraryItemCount = 0,
 } = Astro.props;
 
 const nonFinalCount = draftCount + arbInReviewCount;
 const elevatedLink = getPortalElevatedLink(staffRole);
 const isElevated = role === 'board' || role === 'admin' || role === 'arb' || role === 'arb_board';
 const isStaffFromWhitelist = !!elevatedLink;
+const isStaff = isElevated || isStaffFromWhitelist;
 
 function isCurrent(href: string) {
   if (href === '/portal/dashboard') return currentPath === '/portal/dashboard';
@@ -45,7 +48,7 @@ function isCurrent(href: string) {
 }
 
 // Navigation items with icons
-const mainNavItems = [
+const allNavItems = [
   { label: 'Dashboard', href: '/portal/dashboard', icon: 'home', badge: 0 },
   { label: 'ARB Requests', href: '/portal/requests', icon: 'clipboard', badge: nonFinalCount },
   { label: 'Maintenance', href: '/portal/maintenance', icon: 'wrench', badge: maintenanceOpenCount },
@@ -57,6 +60,14 @@ const mainNavItems = [
   { label: 'Feedback', href: '/portal/feedback', icon: 'message', badge: feedbackDueCount },
   { label: 'Library', href: '/portal/library', icon: 'book', badge: 0 },
 ];
+
+// Hide Library link if no content available (unless user is staff)
+const mainNavItems = allNavItems.filter(item => {
+  if (item.label === 'Library') {
+    return libraryItemCount > 0 || isStaff;
+  }
+  return true;
+});
 
 // Icon SVG paths
 const icons: Record<string, string> = {

--- a/src/lib/portal-badge-counts.ts
+++ b/src/lib/portal-badge-counts.ts
@@ -9,6 +9,7 @@ import { getOwnerByEmail } from './directory-db';
 import { listMaintenanceByHousehold } from './maintenance-db';
 import { listUpcomingWithCountsAndUser, householdHasRsvpd } from './meetings-db';
 import { listActiveFeedbackDocs, getFeedbackResponse, householdHasResponded } from './feedback-db';
+import { countApprovedPreapprovalItems } from './preapproval-db';
 
 export interface PortalBadgeCounts {
   displayName: string | null;
@@ -19,6 +20,7 @@ export interface PortalBadgeCounts {
   maintenanceOpenCount: number;
   meetingsRsvpCount: number;
   feedbackDueCount: number;
+  libraryItemCount: number;
 }
 
 export async function getPortalBadgeCounts(
@@ -55,6 +57,7 @@ export async function getPortalBadgeCounts(
   let maintenanceOpenCount = 0;
   let meetingsRsvpCount = 0;
   let feedbackDueCount = 0;
+  let libraryItemCount = 0;
 
   if (db) {
     const maintenanceList = await listMaintenanceByHousehold(db, email);
@@ -78,6 +81,9 @@ export async function getPortalBadgeCounts(
       if (await householdHasResponded(db, doc.id, email)) continue;
       if (doc.deadline == null || doc.deadline <= tomorrowStr) feedbackDueCount += 1;
     }
+
+    // Library item count (for hiding nav link when empty)
+    libraryItemCount = await countApprovedPreapprovalItems(db);
   }
 
   return {
@@ -89,5 +95,6 @@ export async function getPortalBadgeCounts(
     maintenanceOpenCount,
     meetingsRsvpCount,
     feedbackDueCount,
+    libraryItemCount,
   };
 }

--- a/src/lib/preapproval-db.ts
+++ b/src/lib/preapproval-db.ts
@@ -100,6 +100,14 @@ export async function listPreapprovalCategories(db: D1Database): Promise<string[
   return (results ?? []).map((r) => r.category);
 }
 
+/** Count approved items (for showing/hiding library nav link). */
+export async function countApprovedPreapprovalItems(db: D1Database): Promise<number> {
+  const result = await db
+    .prepare('SELECT COUNT(*) as count FROM preapproval_items WHERE COALESCE(approved, 1) = 1')
+    .first<{ count: number }>();
+  return result?.count ?? 0;
+}
+
 /** Get one item by id. */
 export async function getPreapprovalById(db: D1Database, id: string): Promise<PreapprovalItem | null> {
   return db

--- a/src/pages/board/members.astro
+++ b/src/pages/board/members.astro
@@ -52,6 +52,7 @@ const csrfToken = session?.csrfToken ?? '';
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/board/members" />
 

--- a/src/pages/portal/admin.astro
+++ b/src/pages/portal/admin.astro
@@ -47,6 +47,7 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/portal/admin" />
 

--- a/src/pages/portal/admin/feedback.astro
+++ b/src/pages/portal/admin/feedback.astro
@@ -87,6 +87,7 @@ const csvHref = `/api/site-feedback?${csvParams.toString()}`;
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/portal/admin/feedback" />
 

--- a/src/pages/portal/admin/permissions.astro
+++ b/src/pages/portal/admin/permissions.astro
@@ -84,6 +84,7 @@ Object.values(permissions).forEach((rolePerms) => {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/portal/admin/permissions" />
 

--- a/src/pages/portal/admin/sms-requests.astro
+++ b/src/pages/portal/admin/sms-requests.astro
@@ -61,6 +61,7 @@ const requests = db ? await listSmsFeatureRequests(db, pageSize, (page - 1) * pa
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/portal/admin/sms-requests" />
 

--- a/src/pages/portal/admin/test-email.astro
+++ b/src/pages/portal/admin/test-email.astro
@@ -52,6 +52,7 @@ const csrfToken = session?.csrfToken ?? '';
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/portal/admin/test-email" />
   <div class="space-y-8">

--- a/src/pages/portal/arb-dashboard.astro
+++ b/src/pages/portal/arb-dashboard.astro
@@ -86,6 +86,7 @@ const needsActionCount = inReview.length + pending.length + arcReview.length + b
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <PortalElevatedRoleBanner role={effectiveRole} session={session} />
 

--- a/src/pages/portal/arb-request.astro
+++ b/src/pages/portal/arb-request.astro
@@ -110,6 +110,7 @@ const arbInputClass = 'w-full rounded-lg border border-gray-300 px-4 py-3 text-b
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="max-w-4xl mx-auto">
       <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">

--- a/src/pages/portal/arb.astro
+++ b/src/pages/portal/arb.astro
@@ -47,6 +47,7 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <ArbNav currentPath="/portal/arb" />
 

--- a/src/pages/portal/assessments.astro
+++ b/src/pages/portal/assessments.astro
@@ -137,6 +137,7 @@ function daysRemaining(nextDue: string | null): number | null {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Dues & Balance</h1>

--- a/src/pages/portal/assume-role-help.astro
+++ b/src/pages/portal/assume-role-help.astro
@@ -30,6 +30,7 @@ const isElevated = ['admin', 'arb_board', 'board', 'arb'].includes(effectiveRole
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="max-w-3xl">
       <div class="mb-8">

--- a/src/pages/portal/board.astro
+++ b/src/pages/portal/board.astro
@@ -47,6 +47,7 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <BoardNav currentPath="/portal/board" />
 

--- a/src/pages/portal/compliance.astro
+++ b/src/pages/portal/compliance.astro
@@ -122,6 +122,7 @@ function getDocumentYear(doc: any): number {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <!-- Header -->

--- a/src/pages/portal/dashboard.astro
+++ b/src/pages/portal/dashboard.astro
@@ -16,6 +16,7 @@ import { listMaintenanceByHousehold } from '../../lib/maintenance-db';
 import { listUpcomingWithCountsAndUser, householdHasRsvpd } from '../../lib/meetings-db';
 import { listActiveFeedbackDocs, getFeedbackResponse, householdHasResponded } from '../../lib/feedback-db';
 import { getDismissedKeys } from '../../lib/notification-dismissals';
+import { countApprovedPreapprovalItems } from '../../lib/preapproval-db';
 
 const { env, session, effectiveRole } = await getPortalContext(Astro);
 if (!session) return Astro.redirect('/auth/login');
@@ -54,6 +55,7 @@ const draftCount = allRequests.filter(r => r.status === 'pending').length;
 let maintenanceOpenCount = 0;
 let meetingsRsvpCount = 0;
 let feedbackDueCount = 0;
+let libraryItemCount = 0;
 if (db) {
   const maintenanceList = await listMaintenanceByHousehold(db, email);
   maintenanceOpenCount = maintenanceList.filter((m) => m.status !== 'completed').length;
@@ -74,6 +76,7 @@ if (db) {
     if (await householdHasResponded(db, doc.id, email)) continue;
     if (doc.deadline == null || doc.deadline <= tomorrowStr) feedbackDueCount += 1;
   }
+  libraryItemCount = await countApprovedPreapprovalItems(db);
 }
 const directoryCount = db ? (await listOwners(db)).length : 0;
 
@@ -117,6 +120,7 @@ const showActionNeededBanner = showActionFeedback || showActionMaintenance || sh
       maintenanceOpenCount={maintenanceOpenCount}
       meetingsRsvpCount={meetingsRsvpCount}
       feedbackDueCount={feedbackDueCount}
+      libraryItemCount={libraryItemCount}
     />
 
     <!-- Main Content Area -->

--- a/src/pages/portal/directory.astro
+++ b/src/pages/portal/directory.astro
@@ -4,6 +4,7 @@ export const prerender = false;
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
+import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { getRolesForEmails, isElevatedRole } from '../../lib/auth';
 import { listOwners, countOwners, getOwnerByEmail } from '../../lib/directory-db';
 import { getArbRequestCountsByStatus, listArbRequestsByHousehold } from '../../lib/arb-db';
@@ -18,6 +19,7 @@ if (!session) return Astro.redirect('/auth/login');
 
 const { email, role, name } = session;
 const db = env?.DB;
+const badges = await getPortalBadgeCounts(db, email, role, name);
 
 // User display name
 let displayName = name?.trim() || null;
@@ -106,6 +108,7 @@ function canRevealContact(owner: { share_contact_with_members?: number | null })
     maintenanceOpenCount={maintenanceOpenCount}
     meetingsRsvpCount={meetingsRsvpCount}
     feedbackDueCount={feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-6">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Homeowner Directory</h1>

--- a/src/pages/portal/docs.astro
+++ b/src/pages/portal/docs.astro
@@ -29,6 +29,7 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-2">Portal documentation</h1>

--- a/src/pages/portal/documents.astro
+++ b/src/pages/portal/documents.astro
@@ -4,6 +4,7 @@ export const prerender = false;
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
+import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { getArbRequestCountsByStatus, listArbRequestsByHousehold } from '../../lib/arb-db';
 import { listPendingSubmissions } from '../../lib/vendor-submissions-db';
 import { getOwnerByEmail } from '../../lib/directory-db';
@@ -19,6 +20,7 @@ if (!session) return Astro.redirect('/auth/login');
 
 const { email, role, name } = session;
 const db = env?.DB;
+const badges = await getPortalBadgeCounts(db, email, role, name);
 
 // User display name
 let displayName = name?.trim() || null;
@@ -97,6 +99,7 @@ const docsByCategory = MEMBER_DOC_CATEGORIES.map((cat) => ({
     maintenanceOpenCount={maintenanceOpenCount}
     meetingsRsvpCount={meetingsRsvpCount}
     feedbackDueCount={feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-2">Member Documents</h1>

--- a/src/pages/portal/elevation-audit.astro
+++ b/src/pages/portal/elevation-audit.astro
@@ -70,6 +70,7 @@ function formatDate(s: string | null): string {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="mb-8 p-5 rounded-xl bg-blue-50 border border-blue-200 text-blue-900 text-base" role="status">
       <strong>Read-only.</strong> This page shows when someone requested or dropped elevated access. It does not require you to elevate. For the full audit log (directory, ARB, payments, etc.), use Board → Audit logs after requesting elevated access.

--- a/src/pages/portal/faq.astro
+++ b/src/pages/portal/faq.astro
@@ -29,6 +29,7 @@ const badges = await getPortalBadgeCounts(db, email, role, name);
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Portal FAQ</h1>

--- a/src/pages/portal/feedback.astro
+++ b/src/pages/portal/feedback.astro
@@ -57,6 +57,7 @@ function formatDate(s: string | null): string {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Document Feedback</h1>

--- a/src/pages/portal/library.astro
+++ b/src/pages/portal/library.astro
@@ -61,6 +61,7 @@ const items = db
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-2">Architectural Pre-Approval Library</h1>

--- a/src/pages/portal/maintenance.astro
+++ b/src/pages/portal/maintenance.astro
@@ -43,6 +43,7 @@ function formatDate(s: string): string {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Maintenance Requests</h1>

--- a/src/pages/portal/meetings.astro
+++ b/src/pages/portal/meetings.astro
@@ -60,6 +60,7 @@ function googleCalendarUrl(m: { title: string | null; datetime: string; descript
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Meetings</h1>

--- a/src/pages/portal/my-activity.astro
+++ b/src/pages/portal/my-activity.astro
@@ -82,6 +82,7 @@ function revealType(row: { target_name: string | null; target_phone: string | nu
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">My Activity</h1>

--- a/src/pages/portal/my-requests.astro
+++ b/src/pages/portal/my-requests.astro
@@ -99,6 +99,7 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="max-w-5xl mx-auto">
       <div class="flex flex-wrap items-center justify-between gap-4 mb-6 no-print">

--- a/src/pages/portal/news.astro
+++ b/src/pages/portal/news.astro
@@ -64,6 +64,7 @@ function formatDate(s: string | null): string {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-3">Board Announcements</h1>

--- a/src/pages/portal/preferences.astro
+++ b/src/pages/portal/preferences.astro
@@ -55,6 +55,7 @@ const pushEnabled = notification_preferences['push_enabled'] === true;
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <!-- Page Header -->
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">

--- a/src/pages/portal/profile.astro
+++ b/src/pages/portal/profile.astro
@@ -46,6 +46,7 @@ const allHouseholdMembers = db ? await listAllHouseholdMembers(db, email) : [];
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="max-w-3xl mx-auto">
       <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">

--- a/src/pages/portal/request-elevated-access.astro
+++ b/src/pages/portal/request-elevated-access.astro
@@ -52,6 +52,7 @@ const returnLabel = returnParam && returnParam.startsWith('/board') ? 'Board' : 
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="max-w-2xl">
       <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8">

--- a/src/pages/portal/requests.astro
+++ b/src/pages/portal/requests.astro
@@ -122,6 +122,7 @@ function statusLabel(status: string): string {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-2">Requests</h1>

--- a/src/pages/portal/search.astro
+++ b/src/pages/portal/search.astro
@@ -37,6 +37,7 @@ const result = q && db
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 mb-8">
       <h1 class="text-3xl font-heading font-bold text-clr-green mb-4">Search</h1>

--- a/src/pages/portal/usage.astro
+++ b/src/pages/portal/usage.astro
@@ -104,6 +104,7 @@ const chartDataJson = JSON.stringify(chartData).replace(/<\/script/gi, '<\\/scri
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
     feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     <AdminNav currentPath="/portal/usage" />
 

--- a/src/pages/portal/vendors.astro
+++ b/src/pages/portal/vendors.astro
@@ -4,6 +4,7 @@ export const prerender = false;
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import PortalPage from '../../components/PortalPage.astro';
 import { getPortalContext } from '../../lib/portal-context';
+import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
 import { listPortalVendors } from '../../lib/vendors-db';
 import { getArbRequestCountsByStatus, listArbRequestsByHousehold } from '../../lib/arb-db';
 import { listPendingSubmissions, listVendorSubmissionsByHousehold } from '../../lib/vendor-submissions-db';
@@ -18,6 +19,7 @@ if (!session) return Astro.redirect('/auth/login');
 
 const { email, role, name } = session;
 const db = env?.DB;
+const badges = await getPortalBadgeCounts(db, email, role, name);
 
 // User display name
 let displayName = name?.trim() || null;
@@ -107,6 +109,7 @@ function parseFiles(filesJson: string | null): { name: string; key: string }[] {
     maintenanceOpenCount={maintenanceOpenCount}
     meetingsRsvpCount={meetingsRsvpCount}
     feedbackDueCount={feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
   >
     {submitted && (
       <div class="mb-6 rounded-xl border border-green-200 bg-green-50 p-4" role="status">


### PR DESCRIPTION
## Summary
Implements Issue #136 - Hide the library navigation link from general members when there are no pre-approved items available, while keeping it visible for Board/ARB members who can manage the library.

## Problem
The pre-approval library is currently visible to all members, but there are no pre-approved items available yet. This creates a confusing empty state for general members.

## Solution
Conditionally hide the "Library" navigation link based on:
- **Hide**: When `libraryItemCount === 0` AND user is a general member
- **Show**: When there are approved items OR user is Board/ARB/Admin (who can manage library)

The library page itself remains accessible and shows a good empty state message when there are no items.

## Technical Implementation

### 1. Database Layer
- Added `countApprovedPreapprovalItems()` function to `preapproval-db.ts`
- Counts items where `approved = 1`

### 2. Badge Counts
- Added `libraryItemCount` to `PortalBadgeCounts` interface
- Integrated count query into `getPortalBadgeCounts()` function

### 3. Navigation Component
- Updated `PortalSidebar` to accept `libraryItemCount` prop
- Added filtering logic: `libraryItemCount > 0 || isStaff`
- Staff = board/ARB/admin/arb_board roles

### 4. Component Props
- Updated `PortalPage` to accept and pass `libraryItemCount`
- Updated **33 portal and board pages** to pass `libraryItemCount={badges.libraryItemCount}`

## Files Changed
- **37 files changed**, 72 insertions, 1 deletion
- Core files: preapproval-db.ts, portal-badge-counts.ts, PortalSidebar.astro, PortalPage.astro
- Portal pages: 29 files
- Board pages: 4 files

## Testing
✅ Build completes successfully
✅ Navigation link hidden when library is empty (for members)
✅ Navigation link visible for board/ARB members (can manage library)
✅ Library page still accessible with proper empty state

## User Experience
- **General members**: Won't see confusing empty library link until content is available
- **Board/ARB members**: Always see library link to manage pre-approved items
- **When content added**: Library automatically becomes visible to all members

## Closes
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)