### PR TITLE
fix: Hide Library menu when no items available for all users

### DIFF
--- a/src/components/PortalSidebar.astro
+++ b/src/components/PortalSidebar.astro
@@ -61,10 +61,10 @@ const allNavItems = [
   { label: 'Library', href: '/portal/library', icon: 'book', badge: 0 },
 ];
 
-// Hide Library link if no content available (unless user is staff)
+// Hide Library link if no content available
 const mainNavItems = allNavItems.filter(item => {
   if (item.label === 'Library') {
-    return libraryItemCount > 0 || isStaff;
+    return libraryItemCount > 0;
   }
   return true;
 });


### PR DESCRIPTION
## Summary
Fixes the Library menu showing up for staff/elevated users even when there are no library items, resulting in an empty section.

## Problem
The Library menu visibility logic was:
```typescript
return libraryItemCount > 0 || isStaff;
```

This meant staff users (board, admin, arb) would always see the Library menu, even when `libraryItemCount` was 0, leading to an empty/useless menu item.

## Solution
Changed the logic to only show Library when there are actually items:
```typescript
return libraryItemCount > 0;
```

Now **all users** (including staff) only see the Library menu when there are items to display.

## Changes
- Updated visibility filter in `PortalSidebar.astro`
- Removed `|| isStaff` condition
- Updated comment to reflect new behavior

## Testing
- [x] TypeScript compilation passes (0 errors)
- [ ] Manual test: Login as staff user with 0 library items → Library should be hidden
- [ ] Manual test: Login as staff user with 1+ library items → Library should be visible
- [ ] Manual test: Login as regular user with 0 library items → Library should be hidden
- [ ] Manual test: Login as regular user with 1+ library items → Library should be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)