### PR TITLE
feat: Add dynamic menu ordering system for portal sidebar

### DIFF
--- a/scripts/archive/legacy-migrations/schema-menu-items.sql
+++ b/scripts/archive/legacy-migrations/schema-menu-items.sql
@@ -1,0 +1,31 @@
+-- Add menu_items table for customizable portal menu ordering
+-- Allows admins to reorder and show/hide menu items without code changes
+-- Run: npm run db:menu-items:local or db:menu-items (remote)
+
+CREATE TABLE IF NOT EXISTS menu_items (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  href TEXT NOT NULL,
+  icon TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  visible INTEGER DEFAULT 1,
+  badge_key TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Index for sorting by position
+CREATE INDEX IF NOT EXISTS idx_menu_items_position ON menu_items(position);
+
+-- Insert default menu items (matches current PortalSidebar order)
+INSERT INTO menu_items (id, label, href, icon, position, visible, badge_key) VALUES
+  ('dashboard', 'Dashboard', '/portal/dashboard', 'home', 1, 1, NULL),
+  ('arb-requests', 'ARB Requests', '/portal/requests', 'clipboard', 2, 1, 'nonFinalCount'),
+  ('maintenance', 'Maintenance', '/portal/maintenance', 'wrench', 3, 1, 'maintenanceOpenCount'),
+  ('meetings', 'Meetings', '/portal/meetings', 'calendar', 4, 1, 'meetingsRsvpCount'),
+  ('directory', 'Directory', '/portal/directory', 'users', 5, 1, NULL),
+  ('vendors', 'Vendors', '/portal/vendors', 'briefcase', 6, 1, NULL),
+  ('documents', 'Documents', '/portal/documents', 'folder', 7, 1, NULL),
+  ('dues', 'Dues', '/portal/assessments', 'dollar', 8, 1, NULL),
+  ('feedback', 'Feedback', '/portal/feedback', 'message', 9, 1, 'feedbackDueCount'),
+  ('library', 'Library', '/portal/library', 'book', 10, 1, 'libraryItemCount');

--- a/src/components/PortalSidebar.astro
+++ b/src/components/PortalSidebar.astro
@@ -5,6 +5,7 @@
  * Collapsible on mobile.
  */
 import { getPortalElevatedLink } from '../config/navigation';
+import { getMenuItems } from '../lib/menu-db';
 
 interface Props {
   currentPath: string;
@@ -38,6 +39,19 @@ const isElevated = role === 'board' || role === 'admin' || role === 'arb' || rol
 const isStaffFromWhitelist = !!elevatedLink;
 const isStaff = isElevated || isStaffFromWhitelist;
 
+// Load menu items from database (with fallback to defaults)
+const db = Astro.locals.runtime?.env?.DB;
+const dbMenuItems = db ? await getMenuItems(db) : [];
+
+// Map badge keys to actual values
+const badgeValues: Record<string, number> = {
+  nonFinalCount,
+  maintenanceOpenCount,
+  meetingsRsvpCount,
+  feedbackDueCount,
+  libraryItemCount,
+};
+
 function isCurrent(href: string) {
   if (href === '/portal/dashboard') return currentPath === '/portal/dashboard';
   if (href === '/portal/board') return currentPath === '/portal/board' || currentPath.startsWith('/board/');
@@ -47,19 +61,15 @@ function isCurrent(href: string) {
   return currentPath.startsWith(href);
 }
 
-// Navigation items with icons
-const allNavItems = [
-  { label: 'Dashboard', href: '/portal/dashboard', icon: 'home', badge: 0 },
-  { label: 'ARB Requests', href: '/portal/requests', icon: 'clipboard', badge: nonFinalCount },
-  { label: 'Maintenance', href: '/portal/maintenance', icon: 'wrench', badge: maintenanceOpenCount },
-  { label: 'Meetings', href: '/portal/meetings', icon: 'calendar', badge: meetingsRsvpCount },
-  { label: 'Directory', href: '/portal/directory', icon: 'users', badge: 0 },
-  { label: 'Vendors', href: '/portal/vendors', icon: 'briefcase', badge: 0 },
-  { label: 'Documents', href: '/portal/documents', icon: 'folder', badge: 0 },
-  { label: 'Dues', href: '/portal/assessments', icon: 'dollar', badge: 0 },
-  { label: 'Feedback', href: '/portal/feedback', icon: 'message', badge: feedbackDueCount },
-  { label: 'Library', href: '/portal/library', icon: 'book', badge: 0 },
-];
+// Convert database menu items to nav items format
+const allNavItems = dbMenuItems
+  .filter(item => item.visible === 1) // Only show visible items
+  .map(item => ({
+    label: item.label,
+    href: item.href,
+    icon: item.icon,
+    badge: item.badge_key ? (badgeValues[item.badge_key] || 0) : 0,
+  }));
 
 // Hide Library link if no content available
 const mainNavItems = allNavItems.filter(item => {

--- a/src/lib/menu-db.ts
+++ b/src/lib/menu-db.ts
@@ -1,0 +1,186 @@
+/**
+ * Database helpers for managing portal menu items.
+ * Allows dynamic menu ordering and visibility without code changes.
+ */
+
+export interface MenuItem {
+  id: string;
+  label: string;
+  href: string;
+  icon: string;
+  position: number;
+  visible: number;
+  badge_key: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MenuItemUpdate {
+  position?: number;
+  visible?: number;
+}
+
+/**
+ * Default menu items (fallback if database is empty)
+ * Matches current PortalSidebar.astro order
+ */
+export const DEFAULT_MENU_ITEMS: Omit<MenuItem, 'created_at' | 'updated_at'>[] = [
+  { id: 'dashboard', label: 'Dashboard', href: '/portal/dashboard', icon: 'home', position: 1, visible: 1, badge_key: null },
+  { id: 'arb-requests', label: 'ARB Requests', href: '/portal/requests', icon: 'clipboard', position: 2, visible: 1, badge_key: 'nonFinalCount' },
+  { id: 'maintenance', label: 'Maintenance', href: '/portal/maintenance', icon: 'wrench', position: 3, visible: 1, badge_key: 'maintenanceOpenCount' },
+  { id: 'meetings', label: 'Meetings', href: '/portal/meetings', icon: 'calendar', position: 4, visible: 1, badge_key: 'meetingsRsvpCount' },
+  { id: 'directory', label: 'Directory', href: '/portal/directory', icon: 'users', position: 5, visible: 1, badge_key: null },
+  { id: 'vendors', label: 'Vendors', href: '/portal/vendors', icon: 'briefcase', position: 6, visible: 1, badge_key: null },
+  { id: 'documents', label: 'Documents', href: '/portal/documents', icon: 'folder', position: 7, visible: 1, badge_key: null },
+  { id: 'dues', label: 'Dues', href: '/portal/assessments', icon: 'dollar', position: 8, visible: 1, badge_key: null },
+  { id: 'feedback', label: 'Feedback', href: '/portal/feedback', icon: 'message', position: 9, visible: 1, badge_key: 'feedbackDueCount' },
+  { id: 'library', label: 'Library', href: '/portal/library', icon: 'book', position: 10, visible: 1, badge_key: 'libraryItemCount' },
+];
+
+/**
+ * Get all menu items ordered by position
+ */
+export async function getMenuItems(db: D1Database): Promise<MenuItem[]> {
+  try {
+    const { results } = await db
+      .prepare('SELECT * FROM menu_items ORDER BY position ASC')
+      .all<MenuItem>();
+
+    // If no items in database, return defaults
+    if (!results || results.length === 0) {
+      return DEFAULT_MENU_ITEMS.map(item => ({
+        ...item,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }));
+    }
+
+    return results;
+  } catch (error) {
+    console.error('[menu-db] Failed to get menu items:', error);
+    // Fallback to defaults on error
+    return DEFAULT_MENU_ITEMS.map(item => ({
+      ...item,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }));
+  }
+}
+
+/**
+ * Update menu item (position or visibility)
+ */
+export async function updateMenuItem(
+  db: D1Database,
+  id: string,
+  updates: MenuItemUpdate
+): Promise<boolean> {
+  try {
+    const sets: string[] = [];
+    const values: any[] = [];
+
+    if (updates.position !== undefined) {
+      sets.push('position = ?');
+      values.push(updates.position);
+    }
+    if (updates.visible !== undefined) {
+      sets.push('visible = ?');
+      values.push(updates.visible);
+    }
+
+    if (sets.length === 0) return false;
+
+    sets.push("updated_at = datetime('now')");
+    values.push(id);
+
+    await db
+      .prepare(`UPDATE menu_items SET ${sets.join(', ')} WHERE id = ?`)
+      .bind(...values)
+      .run();
+
+    return true;
+  } catch (error) {
+    console.error('[menu-db] Failed to update menu item:', error);
+    return false;
+  }
+}
+
+/**
+ * Batch update menu item positions (for reordering)
+ */
+export async function updateMenuOrder(
+  db: D1Database,
+  items: Array<{ id: string; position: number }>
+): Promise<boolean> {
+  try {
+    // Use transaction-like approach with multiple updates
+    for (const item of items) {
+      await db
+        .prepare("UPDATE menu_items SET position = ?, updated_at = datetime('now') WHERE id = ?")
+        .bind(item.position, item.id)
+        .run();
+    }
+    return true;
+  } catch (error) {
+    console.error('[menu-db] Failed to update menu order:', error);
+    return false;
+  }
+}
+
+/**
+ * Toggle menu item visibility
+ */
+export async function toggleMenuItemVisibility(
+  db: D1Database,
+  id: string
+): Promise<boolean> {
+  try {
+    await db
+      .prepare("UPDATE menu_items SET visible = 1 - visible, updated_at = datetime('now') WHERE id = ?")
+      .bind(id)
+      .run();
+    return true;
+  } catch (error) {
+    console.error('[menu-db] Failed to toggle visibility:', error);
+    return false;
+  }
+}
+
+/**
+ * Reset menu items to defaults
+ */
+export async function resetMenuToDefaults(db: D1Database): Promise<boolean> {
+  try {
+    // Delete all existing items
+    await db.prepare('DELETE FROM menu_items').run();
+
+    // Insert defaults
+    for (const item of DEFAULT_MENU_ITEMS) {
+      await db
+        .prepare(
+          'INSERT INTO menu_items (id, label, href, icon, position, visible, badge_key) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        )
+        .bind(item.id, item.label, item.href, item.icon, item.position, item.visible, item.badge_key)
+        .run();
+    }
+
+    return true;
+  } catch (error) {
+    console.error('[menu-db] Failed to reset menu to defaults:', error);
+    return false;
+  }
+}
+
+/**
+ * Check if menu_items table exists and has data
+ */
+export async function menuItemsTableExists(db: D1Database): Promise<boolean> {
+  try {
+    const result = await db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='menu_items'")
+      .first();
+    return !!result;
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/pages/api/admin/menu-order.ts
+++ b/src/pages/api/admin/menu-order.ts
@@ -1,0 +1,94 @@
+/**
+ * API endpoint for managing portal menu order
+ * GET: Get current menu items
+ * POST: Update menu order or reset to defaults
+ */
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ locals }) => {
+  const env = locals.runtime?.env;
+  const session = locals.session;
+  const user = locals.user;
+
+  if (!session || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  // Admin only
+  if (user.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+  }
+
+  if (!env?.DB) {
+    return new Response(JSON.stringify({ error: 'Service unavailable' }), { status: 503 });
+  }
+
+  try {
+    const { getMenuItems } = await import('../../../lib/menu-db');
+    const items = await getMenuItems(env.DB);
+
+    return new Response(JSON.stringify({ items }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('[API /admin/menu-order] Error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 });
+  }
+};
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const env = locals.runtime?.env;
+  const session = locals.session;
+  const user = locals.user;
+
+  if (!session || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  // Admin only
+  if (user.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+  }
+
+  if (!env?.DB) {
+    return new Response(JSON.stringify({ error: 'Service unavailable' }), { status: 503 });
+  }
+
+  try {
+    const body = await request.json() as { action?: string; items?: Array<{ id: string; position: number }>; csrf_token?: string };
+
+    // CSRF validation
+    const { verifyCsrfToken } = await import('../../../lib/auth');
+    if (!verifyCsrfToken(session, body.csrf_token)) {
+      return new Response(JSON.stringify({ error: 'Invalid CSRF token' }), { status: 403 });
+    }
+
+    const { updateMenuOrder, resetMenuToDefaults } = await import('../../../lib/menu-db');
+
+    if (body.action === 'reset') {
+      // Reset to defaults
+      const success = await resetMenuToDefaults(env.DB);
+      if (!success) {
+        return new Response(JSON.stringify({ error: 'Failed to reset menu' }), { status: 500 });
+      }
+      return new Response(JSON.stringify({ success: true, message: 'Menu reset to defaults' }), { status: 200 });
+    }
+
+    if (body.action === 'update' && body.items) {
+      // Update order
+      const success = await updateMenuOrder(env.DB, body.items);
+      if (!success) {
+        return new Response(JSON.stringify({ error: 'Failed to update menu order' }), { status: 500 });
+      }
+      return new Response(JSON.stringify({ success: true, message: 'Menu order updated' }), { status: 200 });
+    }
+
+    return new Response(JSON.stringify({ error: 'Invalid action' }), { status: 400 });
+  } catch (error) {
+    console.error('[API /admin/menu-order] Error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 });
+  }
+};

--- a/src/pages/portal/admin/menu-order.astro
+++ b/src/pages/portal/admin/menu-order.astro
@@ -1,0 +1,298 @@
+---
+/**
+ * Admin: Menu Order Management
+ *
+ * Admin-only page for reordering portal sidebar menu items.
+ * Changes are persisted to database and apply immediately.
+ */
+export const prerender = false;
+
+import PortalLayout from '../../../layouts/PortalLayout.astro';
+import PortalPage from '../../../components/PortalPage.astro';
+import AdminNav from '../../../components/AdminNav.astro';
+import { getAdminContext } from '../../../lib/board-context';
+import { getPortalBadgeCounts } from '../../../lib/portal-badge-counts';
+import { getMenuItems } from '../../../lib/menu-db';
+
+const ctx = await getAdminContext(Astro);
+if ('redirect' in ctx) return Astro.redirect(ctx.redirect);
+const { env, session, effectiveRole } = ctx;
+
+const { email, role, name } = session;
+const db = env?.DB;
+const badges = await getPortalBadgeCounts(db, email, role, name);
+
+// Load current menu items
+const menuItems = db ? await getMenuItems(db) : [];
+---
+
+<PortalLayout title="Menu Order | Admin | Member Portal | Crooked Lake Reserve HOA">
+  <PortalPage
+    currentPath="/portal/admin/menu-order"
+    pageTitle="Menu Order"
+    userName={badges.displayName ?? undefined}
+    userEmail={email}
+    effectiveRole={effectiveRole}
+    draftCount={badges.draftCount}
+    role={effectiveRole}
+    staffRole={role ?? ''}
+    arbInReviewCount={badges.arbInReviewCount}
+    vendorPendingCount={badges.vendorPendingCount}
+    maintenanceOpenCount={badges.maintenanceOpenCount}
+    meetingsRsvpCount={badges.meetingsRsvpCount}
+    feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
+  >
+    <AdminNav currentPath="/portal/admin/menu-order" />
+
+    <!-- Page Header -->
+    <div class="mb-6 bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+      <h1 class="text-2xl font-heading font-bold text-clr-green mb-2">Menu Order Management</h1>
+      <p class="text-gray-600">Customize the order of portal sidebar menu items. Changes apply immediately for all users.</p>
+    </div>
+
+    <!-- Info Banner -->
+    <div class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+      <div class="flex items-start gap-3">
+        <svg class="w-5 h-5 text-blue-600 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <div class="flex-1">
+          <h3 class="text-sm font-semibold text-blue-900 mb-1">How to use</h3>
+          <div class="text-sm text-blue-800 space-y-1">
+            <p>• Use ↑↓ arrows to reorder menu items</p>
+            <p>• Click "Save Order" to apply changes</p>
+            <p>• Click "Reset to Default" to restore original order</p>
+            <p>• Changes take effect immediately for all portal users</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Messages -->
+    <div id="message" class="hidden mb-6 p-4 rounded-lg border" role="alert"></div>
+
+    <!-- Menu Items List -->
+    <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+      <h2 class="text-xl font-heading font-semibold text-gray-900 mb-4">Menu Items</h2>
+
+      <div id="menu-items-container" class="space-y-2">
+        {menuItems.map((item) => (
+          <div
+            class="menu-item flex items-center gap-3 p-4 bg-gray-50 rounded-lg border border-gray-200 hover:bg-gray-100 transition-colors"
+            data-id={item.id}
+            data-position={item.position}
+          >
+            <!-- Drag Handle / Icon -->
+            <div class="flex-shrink-0 text-gray-400">
+              <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
+              </svg>
+            </div>
+
+            <!-- Position Number -->
+            <div class="flex-shrink-0 w-8 text-center">
+              <span class="position-number text-sm font-semibold text-gray-600">{item.position}</span>
+            </div>
+
+            <!-- Menu Item Info -->
+            <div class="flex-1">
+              <div class="font-semibold text-gray-900">{item.label}</div>
+              <div class="text-sm text-gray-500">{item.href}</div>
+            </div>
+
+            <!-- Move Buttons -->
+            <div class="flex gap-1">
+              <button
+                type="button"
+                class="move-up p-2 text-gray-600 hover:text-clr-green hover:bg-gray-200 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                title="Move up"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="move-down p-2 text-gray-600 hover:text-clr-green hover:bg-gray-200 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                title="Move down"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="mt-6 flex gap-3 pt-6 border-t border-gray-200">
+        <button
+          type="button"
+          id="save-order-btn"
+          class="px-6 py-3 bg-clr-green text-white rounded-xl font-semibold hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Save Order
+        </button>
+        <button
+          type="button"
+          id="reset-btn"
+          class="px-6 py-3 bg-gray-200 text-gray-700 rounded-xl font-semibold hover:bg-gray-300 transition-all"
+        >
+          Reset to Default
+        </button>
+      </div>
+    </div>
+
+  </PortalPage>
+</PortalLayout>
+
+<script is:inline define:vars={{ csrfToken: session.csrfToken ?? '' }}>
+  (function() {
+    const container = document.getElementById('menu-items-container');
+    const saveBtn = document.getElementById('save-order-btn');
+    const resetBtn = document.getElementById('reset-btn');
+    const messageEl = document.getElementById('message');
+
+    let isDirty = false;
+
+    function showMessage(text, isError) {
+      if (!messageEl) return;
+      messageEl.textContent = text;
+      messageEl.classList.remove('hidden', 'bg-green-50', 'border-green-200', 'text-green-800', 'bg-red-50', 'border-red-200', 'text-red-800');
+      if (isError) {
+        messageEl.classList.add('bg-red-50', 'border-red-200', 'text-red-800');
+      } else {
+        messageEl.classList.add('bg-green-50', 'border-green-200', 'text-green-800');
+      }
+      setTimeout(() => messageEl.classList.add('hidden'), 5000);
+    }
+
+    function updatePositionNumbers() {
+      const items = Array.from(container.querySelectorAll('.menu-item'));
+      items.forEach((item, index) => {
+        const positionNum = index + 1;
+        item.dataset.position = positionNum.toString();
+        item.querySelector('.position-number').textContent = positionNum.toString();
+      });
+      updateButtonStates();
+    }
+
+    function updateButtonStates() {
+      const items = Array.from(container.querySelectorAll('.menu-item'));
+      items.forEach((item, index) => {
+        const upBtn = item.querySelector('.move-up');
+        const downBtn = item.querySelector('.move-down');
+        upBtn.disabled = index === 0;
+        downBtn.disabled = index === items.length - 1;
+      });
+    }
+
+    function moveItem(item, direction) {
+      const sibling = direction === 'up' ? item.previousElementSibling : item.nextElementSibling;
+      if (!sibling) return;
+
+      if (direction === 'up') {
+        container.insertBefore(item, sibling);
+      } else {
+        container.insertBefore(sibling, item);
+      }
+
+      updatePositionNumbers();
+      isDirty = true;
+    }
+
+    // Move button handlers
+    container.addEventListener('click', function(e) {
+      const moveUpBtn = e.target.closest('.move-up');
+      const moveDownBtn = e.target.closest('.move-down');
+
+      if (moveUpBtn) {
+        const item = moveUpBtn.closest('.menu-item');
+        moveItem(item, 'up');
+      } else if (moveDownBtn) {
+        const item = moveDownBtn.closest('.menu-item');
+        moveItem(item, 'down');
+      }
+    });
+
+    // Save order
+    saveBtn.addEventListener('click', async function() {
+      if (!isDirty) {
+        showMessage('No changes to save', false);
+        return;
+      }
+
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving...';
+
+      const items = Array.from(container.querySelectorAll('.menu-item')).map((item, index) => ({
+        id: item.dataset.id,
+        position: index + 1
+      }));
+
+      try {
+        const res = await fetch('/api/admin/menu-order', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'update',
+            items: items,
+            csrf_token: csrfToken,
+          }),
+        });
+
+        const data = await res.json();
+        if (data.success) {
+          showMessage('Menu order saved successfully!', false);
+          isDirty = false;
+        } else {
+          showMessage(data.error || 'Failed to save menu order', true);
+        }
+      } catch (error) {
+        showMessage('Network error. Please try again.', true);
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save Order';
+      }
+    });
+
+    // Reset to defaults
+    resetBtn.addEventListener('click', async function() {
+      if (!confirm('Reset menu to default order? This will undo any custom ordering.')) {
+        return;
+      }
+
+      resetBtn.disabled = true;
+      resetBtn.textContent = 'Resetting...';
+
+      try {
+        const res = await fetch('/api/admin/menu-order', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'reset',
+            csrf_token: csrfToken,
+          }),
+        });
+
+        const data = await res.json();
+        if (data.success) {
+          showMessage('Menu reset to defaults. Reloading...', false);
+          setTimeout(() => window.location.reload(), 1000);
+        } else {
+          showMessage(data.error || 'Failed to reset menu', true);
+        }
+      } catch (error) {
+        showMessage('Network error. Please try again.', true);
+      } finally {
+        resetBtn.disabled = false;
+        resetBtn.textContent = 'Reset to Default';
+      }
+    });
+
+    // Initial setup
+    updatePositionNumbers();
+  })();
+</script>


### PR DESCRIPTION
## Summary
Implements a dynamic menu ordering system that allows admins to reorder portal sidebar menu items through a UI, similar to the permissions management page. No code changes needed for future menu reordering.

## Features

### Admin UI (`/portal/admin/menu-order`)
- ↑↓ arrow buttons to reorder menu items
- Position numbers displayed for each item
- "Save Order" button to persist changes
- "Reset to Default" to restore original order
- Success/error messaging
- Changes apply immediately for all users

### Database Schema
**New table: `menu_items`**
- Stores all 10 current menu items
- Customizable position and visibility
- Badge key mapping for dynamic counts
- Timestamps for audit trail

**Fields:**
- `id` - Unique identifier
- `label` - Display text
- `href` - Link URL
- `icon` - Icon name
- `position` - Sort order (customizable)
- `visible` - Show/hide toggle
- `badge_key` - Maps to dynamic badge counts
- `created_at`, `updated_at` - Audit timestamps

### Backend

**menu-db.ts** - Database helpers:
- `getMenuItems()` - Load ordered items (with defaults fallback)
- `updateMenuOrder()` - Batch update positions
- `toggleMenuItemVisibility()` - Show/hide items
- `resetMenuToDefaults()` - Restore defaults
- `DEFAULT_MENU_ITEMS` - Fallback array matching current sidebar

**API endpoint** - `/api/admin/menu-order`:
- GET: List current menu items
- POST: Update order or reset to defaults
- Admin-only access with CSRF protection

### Frontend Updates

**PortalSidebar.astro:**
- Loads menu items from database
- Falls back to defaults if table doesn't exist
- Maps `badge_key` to dynamic counts (nonFinalCount, libraryItemCount, etc.)
- Respects visibility settings
- Maintains existing Library filtering logic

## Current Menu Items (Default Order)
1. Dashboard
2. ARB Requests (badge: nonFinalCount)
3. Maintenance (badge: maintenanceOpenCount)
4. Meetings (badge: meetingsRsvpCount)
5. Directory
6. Vendors
7. Documents
8. Dues
9. Feedback (badge: feedbackDueCount)
10. Library (badge: libraryItemCount)

## Database Migration
Run before deploying:
```bash
# Local
npx wrangler d1 execute clrhoa_db --local --file=scripts/archive/legacy-migrations/schema-menu-items.sql

# Remote
npx wrangler d1 execute clrhoa_db --remote --file=scripts/archive/legacy-migrations/schema-menu-items.sql
```

## Benefits
✅ No code changes needed to reorder menu
✅ Admin-friendly UI similar to permissions page
✅ Future-proof for adding new menu items
✅ Audit trail with timestamps
✅ Graceful fallback to defaults
✅ Immediate updates for all users

## Testing Checklist
- [ ] Database migration runs successfully
- [ ] Menu order page loads at /portal/admin/menu-order
- [ ] Can reorder items with up/down arrows
- [ ] Save Order persists changes to database
- [ ] Sidebar reflects new order immediately
- [ ] Reset to Default restores original order
- [ ] Non-admin users cannot access page
- [ ] Library item still hidden when libraryItemCount = 0

## Screenshots
[Admin can add screenshots of the menu ordering UI]

🤖 Generated with [Claude Code](https://claude.com/claude-code)