### PR TITLE
fix: Add siteUrl parameter to sendResetEmail for directory users

### DIFF
--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -77,6 +77,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     const normalizedEmail = email.toLowerCase().trim();
 
+    // Extract site URL once for use in all email functions
+    const siteUrl = new URL(request.url).origin;
+
     // 2. Rate limiting - 3 requests per hour per email
     const rateLimitResult = await checkRateLimit(
       kv,
@@ -223,7 +226,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
       if (resend) {
         try {
-          const siteUrl = new URL(request.url).origin;
           await sendSetupEmail(resend, user.email, token, user.name || undefined, siteUrl);
 
           await logSecurityEvent(db, {
@@ -284,7 +286,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
           resend,
           user.email,
           token,
-          user.name || undefined
+          user.name || undefined,
+          siteUrl
         );
 
         // Log successful reset request


### PR DESCRIPTION
Fixes #273

Directory users who request password reset were not receiving emails because the siteUrl parameter was missing from the sendResetEmail call. The siteUrl was only extracted in the pending_setup block, causing it to be out of scope for active user password resets.

## Changes
- Extract siteUrl once at the beginning of the function
- Pass siteUrl to both sendSetupEmail and sendResetEmail calls
- Ensures emails use correct origin URL in all environments

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/dagint/clrhoa-site/actions/runs/22120589770