### PR TITLE
fix: Use correct column name 'created' instead of 'created_at'

### DIFF
--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -166,7 +166,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
           const userId = crypto.randomBytes(16).toString('hex');
           await db
             .prepare(
-              `INSERT INTO users (id, email, name, role, status, created_at)
+              `INSERT INTO users (id, email, name, role, status, created)
                VALUES (?, ?, ?, ?, ?, datetime('now'))`
             )
             .bind(userId, normalizedEmail, directoryEntry.name, role, 'pending_setup')


### PR DESCRIPTION
Fixes the D1 error when directory users request password reset.

The auto-account creation code was referencing `created_at` but the users table schema defines the column as `created`.

Related to #273 and #274

Generated with [Claude Code](https://claude.ai/code)