### PR TITLE
fix: Set user.id field during user creation to fix login redirect loop

### DIFF
--- a/scripts/fix-missing-user-ids.sql
+++ b/scripts/fix-missing-user-ids.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Fix Missing User IDs for Lucia Compatibility
+-- ============================================================================
+-- This migration ensures all users have an 'id' field set (required by Lucia).
+-- For users where id is NULL, set id = email for compatibility.
+--
+-- Issue: #276 - Users redirected back to login page after successful login
+-- Root cause: New users created without 'id' field, causing Lucia session
+-- validation to fail.
+--
+-- Usage:
+--   npm run wrangler d1 execute clrhoa_db --local --file=./scripts/fix-missing-user-ids.sql
+--   npm run wrangler d1 execute clrhoa_db --remote --file=./scripts/fix-missing-user-ids.sql
+-- ============================================================================
+
+-- Update users table: set id = email where id is NULL
+UPDATE users
+SET id = email
+WHERE id IS NULL;
+
+-- Verify the fix
+SELECT
+  COUNT(*) as total_users,
+  COUNT(id) as users_with_id,
+  COUNT(*) - COUNT(id) as users_missing_id
+FROM users;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -53,13 +53,13 @@ export async function upsertUser(
   const normalized = email.trim().toLowerCase();
   await db
     .prepare(
-      `INSERT INTO users (email, role, name, created)
-       VALUES (?, ?, ?, datetime('now'))
+      `INSERT INTO users (id, email, role, name, created)
+       VALUES (?, ?, ?, ?, datetime('now'))
        ON CONFLICT(email) DO UPDATE SET
          name = COALESCE(excluded.name, name),
          role = COALESCE(users.role, excluded.role)`
     )
-    .bind(normalized, role, name ?? null)
+    .bind(normalized, normalized, role, name ?? null)
     .run();
 
   const user = await getUserByEmail(db, normalized);

--- a/src/pages/api/admin/users/create.ts
+++ b/src/pages/api/admin/users/create.ts
@@ -135,6 +135,7 @@ export const POST: APIRoute = async (context) => {
     await db
       .prepare(
         `INSERT INTO users (
+          id,
           email,
           role,
           name,
@@ -143,9 +144,10 @@ export const POST: APIRoute = async (context) => {
           created_by,
           created,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
       )
       .bind(
+        normalizedEmail,
         normalizedEmail,
         normalizedRole,
         name || null,


### PR DESCRIPTION
## Summary

Fixes #276

New users were experiencing a redirect loop after successful login. The issue was that user creation functions were not setting the `id` field, which is required by the Lucia D1 adapter for session validation.

## Changes

- Fixed `upsertUser()` in `src/lib/db.ts` to set `id = email`
- Fixed user creation in `src/pages/api/admin/users/create.ts`
- Added migration script `scripts/fix-missing-user-ids.sql` to fix existing users

## Testing

1. Create a new user via admin panel
2. Complete password setup
3. Login with new credentials
4. Verify user is redirected to /portal/dashboard instead of login page

## Post-Merge

Run the migration to fix existing users:
```bash
npm run wrangler d1 execute clrhoa_db --remote --file=./scripts/fix-missing-user-ids.sql
```

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/dagint/clrhoa-site/actions/runs/22122608959