### PR TITLE
fix: Increase ARB file upload limits (#286)

### DIFF
--- a/src/pages/api/arb-add-files.astro
+++ b/src/pages/api/arb-add-files.astro
@@ -11,8 +11,8 @@ import { checkRateLimit, getRateLimitConfig } from '../../lib/rate-limit';
 import { getSecurityMonitor } from '../../lib/monitoring';
 import { listArbFilesByRequest, createArbFileId, insertArbFile } from '../../lib/arb-db';
 
-const MAX_FILE_BYTES = 5 * 1024 * 1024;
-const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10MB per file
+const MAX_TOTAL_BYTES = 40 * 1024 * 1024; // 40MB total
 const MAX_REQUEST_SIZE_BYTES = 100 * 1024 * 1024; // 100MB max request size
 const REQUEST_TIMEOUT_MS = 30 * 1000; // 30 seconds timeout
 

--- a/src/pages/api/arb-auto-save.astro
+++ b/src/pages/api/arb-auto-save.astro
@@ -20,8 +20,8 @@ import {
 } from '../../lib/arb-db';
 import { listEmailsAtSameAddress } from '../../lib/directory-db.js';
 
-const MAX_FILE_BYTES = 5 * 1024 * 1024;
-const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10MB per file
+const MAX_TOTAL_BYTES = 40 * 1024 * 1024; // 40MB total
 const ALLOWED_TYPES = [
   'image/jpeg',
   'image/png',

--- a/src/pages/api/arb-upload.astro
+++ b/src/pages/api/arb-upload.astro
@@ -2,7 +2,7 @@
 /**
  * POST /api/arb-upload — authenticated ARB request submission.
  * Multipart: description, esign (checkbox), files[] (image/* or PDF).
- * Limits: 5MB per file, 25MB total. Stores in R2 (originals/; review/ & archive/ when client-side resized).
+ * Limits: 10MB per file, 40MB total. Stores in R2 (originals/; review/ & archive/ when client-side resized).
  */
 export const prerender = false;
 
@@ -24,8 +24,8 @@ import {
 } from '../../lib/esignature-db';
 import { formatEasternDate } from '../../lib/timezone';
 
-const MAX_FILE_BYTES = 5 * 1024 * 1024;
-const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10MB per file (construction plans, blueprints, high-res photos)
+const MAX_TOTAL_BYTES = 40 * 1024 * 1024; // 40MB total (allows 4 large files or many small ones)
 const MAX_REQUEST_SIZE_BYTES = 100 * 1024 * 1024; // 100MB max request size (Cloudflare Workers default)
 const REQUEST_TIMEOUT_MS = 30 * 1000; // 30 seconds timeout for file uploads
 const ALLOWED_TYPES = [

--- a/src/pages/portal/arb-request.astro
+++ b/src/pages/portal/arb-request.astro
@@ -265,7 +265,7 @@ const arbInputClass = 'w-full rounded-lg border border-gray-300 px-4 py-3 text-b
             Attachments <span class="text-gray-400 font-normal">(optional but recommended)</span>
             <span class="ml-1 text-gray-400 cursor-help" title="Photos are resized before upload. PDFs stay full quality. By submitting you confirm you have reviewed your attachments." aria-label="Help: Attachments">(i)</span>
           </label>
-          <p class="text-sm text-gray-500 mb-2">Submit as applicable: written description, lot survey, specifications (plans, dimensions, materials, colors), paint/color samples, photos, brochures. Max 5MB per file, 25MB total. <strong>Photos are resized before upload</strong> to save space; PDFs are kept as-is. By submitting, you confirm you have reviewed your attachments. Allowed: JPEG, PNG, GIF, WebP, HEIC, PDF.</p>
+          <p class="text-sm text-gray-500 mb-2">Submit as applicable: written description, lot survey, specifications (plans, dimensions, materials, colors), paint/color samples, photos, brochures. Max 10MB per file, 40MB total. <strong>Photos are resized before upload</strong> to save space; PDFs are kept as-is. By submitting, you confirm you have reviewed your attachments. Allowed: JPEG, PNG, GIF, WebP, HEIC, PDF.</p>
           <input
             type="file"
             name="files"
@@ -309,7 +309,7 @@ const arbInputClass = 'w-full rounded-lg border border-gray-300 px-4 py-3 text-b
       </form>
     </div>
 
-  <script is:inline define:vars={{ maxFileBytes: 5 * 1024 * 1024, maxTotalBytes: 25 * 1024 * 1024, reviewMaxWidth: 2000, archiveMaxWidth: 1200 }}>
+  <script is:inline define:vars={{ maxFileBytes: 10 * 1024 * 1024, maxTotalBytes: 40 * 1024 * 1024, reviewMaxWidth: 2000, archiveMaxWidth: 1200 }}>
     (function () {
       const form = document.getElementById('arb-form');
       const fileInput = form?.querySelector('input[name="files"]');
@@ -477,14 +477,14 @@ const arbInputClass = 'w-full rounded-lg border border-gray-300 px-4 py-3 text-b
           let total = 0;
           for (const f of files) {
             if (f.size > maxFileBytes) {
-              showErr(fileError, `"${f.name}" exceeds 5MB. Maximum 5MB per file.`);
+              showErr(fileError, `"${f.name}" exceeds 10MB. Maximum 10MB per file.`);
               if (fileSizePreview) { fileSizePreview.classList.add('hidden'); }
               return;
             }
             total += f.size;
           }
           if (total > maxTotalBytes) {
-            showErr(fileError, `Total size ${(total / 1024 / 1024).toFixed(1)}MB exceeds 25MB limit.`);
+            showErr(fileError, `Total size ${(total / 1024 / 1024).toFixed(1)}MB exceeds 40MB limit.`);
           }
           // Show file size preview
           if (fileSizePreview && files.length > 0) {

--- a/src/pages/portal/arb-request/edit/[id].astro
+++ b/src/pages/portal/arb-request/edit/[id].astro
@@ -205,7 +205,7 @@ const selectedTypes = req.application_type ? req.application_type.split(',').map
           ) : (
             <p class="text-sm text-gray-500 mb-4">No attachments yet.</p>
           )}
-          <p class="text-sm text-gray-500 mb-2">Add more: images or PDF, 5MB per file, 25MB total. Photos are resized before upload; by adding them you confirm you have reviewed the selection.</p>
+          <p class="text-sm text-gray-500 mb-2">Add more: images or PDF, 10MB per file, 40MB total. Photos are resized before upload; by adding them you confirm you have reviewed the selection.</p>
           <input type="file" id="add-files-input" name="add_files" multiple accept="image/*,application/pdf" class="w-full text-sm text-gray-600 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-clr-beige file:text-clr-green file:font-semibold" />
           <button type="button" id="add-files-btn" class="mt-2 px-4 py-2 rounded-lg border border-gray-300 bg-white hover:bg-gray-50 text-sm font-semibold text-gray-700">Add selected files</button>
           <p id="add-files-error" class="mt-1 text-sm text-red-600 hidden" role="alert"></p>
@@ -239,7 +239,7 @@ const selectedTypes = req.application_type ? req.application_type.split(',').map
       </form>
     </div>
 
-  <script is:inline define:vars={{ requestId: req.id, reviewMaxWidth: 2000, archiveMaxWidth: 1200, maxFileBytes: 5 * 1024 * 1024, maxTotalBytes: 25 * 1024 * 1024 }}>
+  <script is:inline define:vars={{ requestId: req.id, reviewMaxWidth: 2000, archiveMaxWidth: 1200, maxFileBytes: 10 * 1024 * 1024, maxTotalBytes: 40 * 1024 * 1024 }}>
     (function () {
       const form = document.getElementById('arb-edit-form');
       const formError = document.getElementById('form-error');
@@ -377,7 +377,7 @@ const selectedTypes = req.application_type ? req.application_type.split(',').map
             for (var i = 0; i < files.length; i++) {
               var file = files[i];
               if (file.size > maxFileBytes) {
-                addFilesError.textContent = 'File "' + file.name + '" exceeds 5MB.';
+                addFilesError.textContent = 'File "' + file.name + '" exceeds 10MB.';
                 addFilesError.classList.remove('hidden');
                 addFilesBtn.disabled = false;
                 addFilesBtn.textContent = 'Add selected files';


### PR DESCRIPTION
## Summary
Increases ARB file upload limits to accommodate construction plans, blueprints, and high-resolution photos.

## Issue #286: Allow Larger File Uploads + Compression ✅

**Problem**: Current 5MB per-file limit was too restrictive for:
- Construction plans and blueprints (typically 7-10MB PDFs)
- High-resolution architectural photos
- Detailed specifications and drawings

**Solution**: Increased limits while maintaining existing client-side compression:
- **Per-file limit**: 5MB → **10MB** (2x increase)
- **Total upload limit**: 25MB → **40MB** (1.6x increase)

## How It Works

**Image Compression** (unchanged):
- Client-side compression using HTML5 Canvas API
- Review version: Max 2000px width, 82% quality
- Archive version: Max 1200px width, 70% quality
- Large photos automatically reduced to fit

**PDF Handling**:
- No compression (preserves quality for plans/blueprints)
- Now supports up to 10MB per PDF
- Allows 4 large PDFs or many smaller files (40MB total)

## Files Updated

**API Endpoints** (3):
- `arb-upload.astro` - New submission
- `arb-auto-save.astro` - Draft auto-save
- `arb-add-files.astro` - Add files to existing request

**Frontend Pages** (2):
- `arb-request.astro` - New request form
- `arb-request/edit/[id].astro` - Edit existing request

**Changes Per File**:
- Updated MAX_FILE_BYTES constant
- Updated MAX_TOTAL_BYTES constant  
- Updated user-facing messages
- Updated error messages
- Updated inline comments

## Testing
- ✅ Build passes
- ✅ TypeScript check passes
- 🔄 Users can now upload larger files after deployment

## Technical Notes
- Cloudflare Workers max request size: 100MB (plenty of headroom)
- R2 storage: Unlimited, only costs $0.015/GB/month
- Client-side compression reduces bandwidth and storage costs
- No changes to compression logic (already optimal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)