### PR TITLE
feat: Add admin ability to delete site feedback (#307)

### DIFF
--- a/src/lib/site-feedback-db.ts
+++ b/src/lib/site-feedback-db.ts
@@ -102,3 +102,19 @@ export async function listSiteFeedback(
 
   return results ?? [];
 }
+
+/**
+ * Delete a site feedback entry by ID (admin only).
+ * Returns true if deleted, false if not found.
+ */
+export async function deleteSiteFeedback(
+  db: D1Database,
+  id: string
+): Promise<boolean> {
+  const result = await db
+    .prepare('DELETE FROM site_feedback WHERE id = ?')
+    .bind(id)
+    .run();
+
+  return (result.meta?.changes ?? 0) > 0;
+}

--- a/src/pages/api/site-feedback-delete.ts
+++ b/src/pages/api/site-feedback-delete.ts
@@ -1,0 +1,86 @@
+/**
+ * DELETE /api/site-feedback-delete
+ *
+ * Admin-only endpoint to delete a specific site feedback entry.
+ * Logs the deletion for audit purposes.
+ */
+
+import type { APIContext } from 'astro';
+import { getEffectiveRole } from '../../lib/auth';
+import { deleteSiteFeedback } from '../../lib/site-feedback-db';
+import { logAdminEvent } from '../../lib/audit-log';
+
+export const prerender = false;
+
+export async function POST(context: APIContext): Promise<Response> {
+  const env = context.locals.runtime?.env;
+  const user = context.locals.user;
+  const session = context.locals.session;
+
+  if (!user || !session || !env?.DB) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const effectiveRole = getEffectiveRole(session);
+  if (effectiveRole !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden. Admin access required.' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body: { id?: string };
+  try {
+    body = await context.request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const feedbackId = body.id?.trim();
+  if (!feedbackId) {
+    return new Response(JSON.stringify({ error: 'Feedback ID is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const deleted = await deleteSiteFeedback(env.DB, feedbackId);
+
+    if (!deleted) {
+      return new Response(JSON.stringify({ error: 'Feedback not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Log the deletion for audit purposes
+    await logAdminEvent(env.DB, {
+      eventType: 'delete_site_feedback',
+      userId: user.email,
+      action: `Deleted site feedback entry`,
+      resourceType: 'site_feedback',
+      resourceId: feedbackId,
+      details: { feedbackId },
+      ipAddress: context.clientAddress || null,
+    });
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Error deleting site feedback:', error);
+    return new Response(JSON.stringify({ error: 'Failed to delete feedback' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/pages/portal/admin/feedback.astro
+++ b/src/pages/portal/admin/feedback.astro
@@ -158,17 +158,28 @@ const csvHref = `/api/site-feedback?${csvParams.toString()}`;
               <th class="text-left py-2 px-3 font-medium text-gray-700">Viewport</th>
               <th class="text-left py-2 px-3 font-medium text-gray-700">Session</th>
               <th class="text-left py-2 px-3 font-medium text-gray-700">Comment</th>
+              <th class="text-left py-2 px-3 font-medium text-gray-700">Actions</th>
             </tr>
           </thead>
           <tbody>
             {feedback.map((row) => (
-              <tr class="border-b border-gray-100 hover:bg-gray-50/50">
+              <tr class="border-b border-gray-100 hover:bg-gray-50/50" data-feedback-id={row.id}>
                 <td class="py-2 px-3 text-gray-600 whitespace-nowrap">{formatEasternDateTime(row.created_at)}</td>
                 <td class="py-2 px-3">{row.thumbs === 1 ? '👍' : '👎'}</td>
                 <td class="py-2 px-3 max-w-xs truncate" title={row.url}>{row.url || '—'}</td>
                 <td class="py-2 px-3 text-gray-600">{row.viewport ?? '—'}</td>
                 <td class="py-2 px-3 font-mono text-gray-500 text-xs">{row.session_id ?? '—'}</td>
                 <td class="py-2 px-3 max-w-sm">{row.comment ?? '—'}</td>
+                <td class="py-2 px-3">
+                  <button
+                    type="button"
+                    class="delete-feedback-btn text-red-600 hover:text-red-800 text-sm font-medium transition-colors"
+                    data-feedback-id={row.id}
+                    title="Delete this feedback"
+                  >
+                    Delete
+                  </button>
+                </td>
               </tr>
             ))}
           </tbody>
@@ -188,4 +199,57 @@ const csvHref = `/api/site-feedback?${csvParams.toString()}`;
     </div>
     </div>
   </PortalPage>
+
+  <script is:inline>
+    (function() {
+      document.querySelectorAll('.delete-feedback-btn').forEach(function(btn) {
+        btn.addEventListener('click', async function() {
+          const feedbackId = this.getAttribute('data-feedback-id');
+          if (!feedbackId) return;
+
+          const confirmed = confirm('Are you sure you want to delete this feedback entry? This action cannot be undone.');
+          if (!confirmed) return;
+
+          const row = this.closest('tr');
+          btn.disabled = true;
+          btn.textContent = 'Deleting...';
+
+          try {
+            const res = await fetch('/api/site-feedback-delete', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ id: feedbackId })
+            });
+
+            const data = await res.json();
+
+            if (res.ok && data.success) {
+              // Fade out and remove the row
+              if (row) {
+                row.style.transition = 'opacity 0.3s';
+                row.style.opacity = '0';
+                setTimeout(function() {
+                  row.remove();
+                  // Reload page if no rows left
+                  const remainingRows = document.querySelectorAll('tbody tr').length;
+                  if (remainingRows === 0) {
+                    window.location.reload();
+                  }
+                }, 300);
+              }
+            } else {
+              alert(data.error || 'Failed to delete feedback entry');
+              btn.disabled = false;
+              btn.textContent = 'Delete';
+            }
+          } catch (error) {
+            console.error('Delete error:', error);
+            alert('Network error. Please try again.');
+            btn.disabled = false;
+            btn.textContent = 'Delete';
+          }
+        });
+      });
+    })();
+  </script>
 </PortalLayout>


### PR DESCRIPTION
## Summary
Adds the ability for admins to delete specific site feedback entries for privacy concerns, non-constructive content, or addressed items.

## Fixes
- **#307**: admins should be able to delete specific site feedback

## Features

### Delete Button
- Added "Actions" column to admin feedback table
- Delete button for each feedback entry
- Confirmation dialog before deletion
- Smooth fade-out animation on success
- Auto-reload if last item on page is deleted

### Audit Logging
- All deletions logged to `audit_logs` table
- Logs include:
  - Event type: `delete_site_feedback`
  - User ID (admin who deleted)
  - Resource ID (feedback ID)
  - IP address
  - Timestamp

## Changes

### 1. Database Function
**File**: `src/lib/site-feedback-db.ts`
- Added `deleteSiteFeedback(db, id)` function
- Returns `true` if deleted, `false` if not found
- Uses D1 DELETE query with feedback ID

### 2. API Endpoint
**File**: `src/pages/api/site-feedback-delete.ts`
- New endpoint: `POST /api/site-feedback-delete`
- Admin-only access (checks `effectiveRole === 'admin'`)
- Accepts JSON body: `{ id: string }`
- Returns:
  - 200: `{ success: true }` if deleted
  - 404: `{ error: 'Feedback not found' }` if ID doesn't exist
  - 401/403: Unauthorized/Forbidden for non-admins
- Logs deletion to audit_logs using `logAdminEvent()`

### 3. UI Updates
**File**: `src/pages/portal/admin/feedback.astro`
- Added "Actions" column header
- Delete button in each row with `data-feedback-id` attribute
- JavaScript handler:
  - Shows confirmation dialog
  - Calls `/api/site-feedback-delete` endpoint
  - Fades out row on success
  - Reloads page if last row deleted
  - Shows error alert if deletion fails

## Security

- **Authorization**: Admin role required (`effectiveRole === 'admin'`)
- **Audit Trail**: Every deletion logged with actor, resource, and timestamp
- **Confirmation**: User must confirm before deletion
- **No Cascade**: Only deletes the specific feedback entry

## Use Cases

1. **Privacy Concerns**: Remove feedback containing PII or sensitive information
2. **Non-Constructive Content**: Delete spam or unhelpful feedback
3. **Addressed Items**: Archive feedback that has been resolved

## Test Plan

### 1. Test as Admin
- [x] Login as admin and elevate
- [ ] Navigate to /portal/admin/feedback
- [ ] Verify "Actions" column appears
- [ ] Click "Delete" on a feedback entry
- [ ] Verify confirmation dialog appears
- [ ] Confirm deletion
- [ ] Verify row fades out and disappears
- [ ] Check audit logs for deletion event

### 2. Test as Non-Admin
- [ ] Login as regular member
- [ ] Try to access /api/site-feedback-delete directly
- [ ] Verify 403 Forbidden response

### 3. Test Edge Cases
- [ ] Delete last item on a page → verify page reloads
- [ ] Try to delete non-existent feedback ID → verify 404 error
- [ ] Cancel confirmation dialog → verify nothing deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)