### PR TITLE
fix: Show correct navigation for admin on audit logs (#308)

### DIFF
--- a/src/pages/portal/board/audit-logs.astro
+++ b/src/pages/portal/board/audit-logs.astro
@@ -113,7 +113,13 @@ function formatDate(s: string | null): string {
     maintenanceOpenCount={badges.maintenanceOpenCount}
     meetingsRsvpCount={badges.meetingsRsvpCount}
   >
-    <ElevatedNav persona="board" currentPath="/portal/board/audit-logs" effectiveRole={effectiveRole} user={{ email, role: role ?? '' }} session={session} />
+    <ElevatedNav
+      persona={effectiveRole === 'admin' ? 'admin' : 'board'}
+      currentPath={effectiveRole === 'admin' ? '/portal/admin/audit-logs' : '/portal/board/audit-logs'}
+      effectiveRole={effectiveRole}
+      user={{ email, role: role ?? '' }}
+      session={session}
+    />
 
 <p class="text-gray-600 mb-4">
         Full audit logs for transparency: PIM elevated access requests, directory (contact reveals, who added/updated owners), assessment payments recorded, vendor list changes and vendor submission approvals/rejections, member document uploads, special assessments, preapproval library, feedback docs, meetings, and ARB status changes. <strong>Revealed contact information (phone numbers and emails that were viewed) is redacted for privacy, but the identity of who performed each action is shown for accountability.</strong>


### PR DESCRIPTION
## Summary
Fixes navigation issue where admin users saw board navigation when viewing audit logs.

## Issue
- **#308**: When elevated to admin and clicking audit logs, navigation switches to board menu and shows "Elevated as Board" even though user elevated as admin

## Root Cause
The `/portal/admin/audit-logs` page redirects to `/portal/board/audit-logs`, which hardcoded `persona="board"` in the ElevatedNav component, ignoring the user's actual elevated role.

## Solution
Dynamically determine the persona and currentPath based on `effectiveRole`:
- If `effectiveRole === 'admin'` → show admin navigation and admin currentPath
- Otherwise → show board navigation and board currentPath

## Changes
**File**: `src/pages/portal/board/audit-logs.astro`
- Changed from hardcoded `persona="board"` 
- To dynamic: `persona={effectiveRole === 'admin' ? 'admin' : 'board'}`
- Also dynamically set currentPath to match the persona

## Result
- Admins now see admin navigation menu
- Elevation banner shows "Elevated as Administrator"
- Navigation highlights correct menu item
- Board members still see board navigation as before

Fixes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)