### PR TITLE
feat: Add board and ARB leadership directory page

### DIFF
--- a/src/lib/menu-db.ts
+++ b/src/lib/menu-db.ts
@@ -30,11 +30,12 @@ export const DEFAULT_MENU_ITEMS: Omit<MenuItem, 'created_at' | 'updated_at'>[] =
   { id: 'maintenance', label: 'Maintenance', href: '/portal/maintenance', icon: 'wrench', position: 3, visible: 1, badge_key: 'maintenanceOpenCount' },
   { id: 'meetings', label: 'Meetings', href: '/portal/meetings', icon: 'calendar', position: 4, visible: 1, badge_key: 'meetingsRsvpCount' },
   { id: 'directory', label: 'Directory', href: '/portal/directory', icon: 'users', position: 5, visible: 1, badge_key: null },
-  { id: 'vendors', label: 'Vendors', href: '/portal/vendors', icon: 'briefcase', position: 6, visible: 1, badge_key: null },
-  { id: 'documents', label: 'Documents', href: '/portal/documents', icon: 'folder', position: 7, visible: 1, badge_key: null },
-  { id: 'dues', label: 'Dues', href: '/portal/assessments', icon: 'dollar', position: 8, visible: 1, badge_key: null },
-  { id: 'feedback', label: 'Feedback', href: '/portal/feedback', icon: 'message', position: 9, visible: 1, badge_key: 'feedbackDueCount' },
-  { id: 'library', label: 'Library', href: '/portal/library', icon: 'book', position: 10, visible: 1, badge_key: 'libraryItemCount' },
+  { id: 'leadership', label: 'Leadership', href: '/portal/leadership', icon: 'star', position: 6, visible: 1, badge_key: null },
+  { id: 'vendors', label: 'Vendors', href: '/portal/vendors', icon: 'briefcase', position: 7, visible: 1, badge_key: null },
+  { id: 'documents', label: 'Documents', href: '/portal/documents', icon: 'folder', position: 8, visible: 1, badge_key: null },
+  { id: 'dues', label: 'Dues', href: '/portal/assessments', icon: 'dollar', position: 9, visible: 1, badge_key: null },
+  { id: 'feedback', label: 'Feedback', href: '/portal/feedback', icon: 'message', position: 10, visible: 1, badge_key: 'feedbackDueCount' },
+  { id: 'library', label: 'Library', href: '/portal/library', icon: 'book', position: 11, visible: 1, badge_key: 'libraryItemCount' },
 ];
 
 /**

--- a/src/pages/portal/leadership.astro
+++ b/src/pages/portal/leadership.astro
@@ -1,0 +1,259 @@
+---
+/**
+ * Board and ARB Leadership Directory
+ *
+ * Member-only page displaying current board members, ARB members, and administrators
+ * with their titles and contact information. Board/ARB/Admin positions are required
+ * disclosure per HOA governance requirements.
+ */
+export const prerender = false;
+
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import PortalPage from '../../components/PortalPage.astro';
+import { getPortalContext } from '../../lib/portal-context';
+import { getPortalBadgeCounts } from '../../lib/portal-badge-counts';
+import { getCurrentPositions, BOARD_TITLES } from '../../lib/board-positions-db';
+import { getMemberByEmail } from '../../lib/members-db';
+
+const { env, session } = await getPortalContext(Astro);
+if (!session) return Astro.redirect('/auth/login');
+
+const { email, role, name } = session;
+const db = env?.DB;
+const badges = await getPortalBadgeCounts(db, email, role, name);
+
+// Get all current board/ARB positions
+const positions = db ? await getCurrentPositions(db) : [];
+
+// Fetch contact details for each position holder
+const positionsWithDetails = await Promise.all(
+  positions.map(async (pos) => {
+    const member = db ? await getMemberByEmail(db, pos.email) : null;
+    return {
+      ...pos,
+      phone: member?.phone || null,
+      address: member?.address || null,
+    };
+  })
+);
+
+// Get all admin users
+const admins = db
+  ? await db.prepare('SELECT email, name FROM users WHERE role = ? AND status = ?')
+      .bind('admin', 'active')
+      .all<{ email: string; name: string | null }>()
+  : { results: [] };
+
+const adminUsers = await Promise.all(
+  (admins.results || []).map(async (admin) => {
+    const member = db ? await getMemberByEmail(db, admin.email) : null;
+    return {
+      email: admin.email,
+      name: admin.name || member?.name || null,
+      phone: member?.phone || null,
+    };
+  })
+);
+
+// Separate positions into Board and ARB
+const boardPositions = positionsWithDetails.filter(p =>
+  [BOARD_TITLES.PRESIDENT, BOARD_TITLES.VICE_PRESIDENT, BOARD_TITLES.SECRETARY,
+   BOARD_TITLES.TREASURER, BOARD_TITLES.MEMBER_AT_LARGE].includes(p.title as any)
+);
+
+const arbPositions = positionsWithDetails.filter(p =>
+  [BOARD_TITLES.ARB_CHAIR, BOARD_TITLES.ARB_MEMBER].includes(p.title as any)
+);
+
+// Title order for display
+const titleOrder = {
+  'President': 1,
+  'Vice President': 2,
+  'Secretary': 3,
+  'Treasurer': 4,
+  'Member at Large': 5,
+  'ARB Chair': 6,
+  'ARB Member': 7,
+};
+---
+
+<PortalLayout title="Leadership Directory | Member Portal | Crooked Lake Reserve HOA">
+  <PortalPage
+    currentPath="/portal/leadership"
+    pageTitle="Leadership Directory"
+    userName={badges.displayName ?? undefined}
+    userEmail={email}
+    effectiveRole={role ?? 'member'}
+    draftCount={badges.draftCount}
+    role={role ?? 'member'}
+    staffRole={role ?? ''}
+    arbInReviewCount={badges.arbInReviewCount}
+    vendorPendingCount={badges.vendorPendingCount}
+    maintenanceOpenCount={badges.maintenanceOpenCount}
+    meetingsRsvpCount={badges.meetingsRsvpCount}
+    feedbackDueCount={badges.feedbackDueCount}
+    libraryItemCount={badges.libraryItemCount}
+  >
+    <div class="mb-8">
+      <h1 class="text-3xl font-heading font-bold text-clr-green mb-2">Leadership Directory</h1>
+      <p class="text-gray-600 text-lg">Current board members, ARB committee, and administrators</p>
+    </div>
+
+    <!-- Contact Information Notice -->
+    <div class="bg-blue-50 border-l-4 border-blue-500 p-6 mb-8 rounded-r-xl">
+      <h2 class="text-xl font-semibold text-blue-900 mb-3">Official Contact Information</h2>
+      <div class="space-y-2 text-blue-800">
+        <p class="flex items-center gap-2">
+          <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+          </svg>
+          <strong>To contact the Board of Directors:</strong> <a href="mailto:board@clrhoa.com" class="underline hover:text-blue-600">board@clrhoa.com</a>
+        </p>
+        <p class="flex items-center gap-2">
+          <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+          </svg>
+          <strong>To contact the ARB Committee:</strong> <a href="mailto:arb@clrhoa.com" class="underline hover:text-blue-600">arb@clrhoa.com</a>
+        </p>
+      </div>
+      <p class="text-sm text-blue-700 mt-3">
+        Individual contact details below are provided for reference. For official HOA business, please use the email addresses above.
+      </p>
+    </div>
+
+    <!-- Board of Directors -->
+    <section class="mb-10">
+      <h2 class="text-2xl font-heading font-semibold text-clr-green mb-6 flex items-center gap-3">
+        <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+        </svg>
+        Board of Directors
+      </h2>
+
+      {boardPositions.length === 0 ? (
+        <p class="text-gray-500 p-6 bg-gray-50 rounded-xl">No board positions currently filled.</p>
+      ) : (
+        <div class="grid gap-4">
+          {boardPositions
+            .sort((a, b) => (titleOrder[a.title as keyof typeof titleOrder] || 99) - (titleOrder[b.title as keyof typeof titleOrder] || 99))
+            .map((pos) => (
+              <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                  <div class="flex-1">
+                    <div class="flex items-center gap-3 mb-2">
+                      <h3 class="text-xl font-semibold text-clr-green">{pos.title}</h3>
+                      <span class="px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">Board</span>
+                    </div>
+                    <p class="text-lg text-gray-800 font-medium mb-1">{pos.name || pos.email}</p>
+                    {pos.phone && (
+                      <p class="text-gray-600 flex items-center gap-2">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+                        </svg>
+                        {pos.phone}
+                      </p>
+                    )}
+                    <p class="text-sm text-gray-500 mt-2">
+                      Term started: {new Date(pos.start_date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+        </div>
+      )}
+    </section>
+
+    <!-- ARB Committee -->
+    <section class="mb-10">
+      <h2 class="text-2xl font-heading font-semibold text-clr-green mb-6 flex items-center gap-3">
+        <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        Architectural Review Board (ARB)
+      </h2>
+
+      {arbPositions.length === 0 ? (
+        <p class="text-gray-500 p-6 bg-gray-50 rounded-xl">No ARB positions currently filled.</p>
+      ) : (
+        <div class="grid gap-4">
+          {arbPositions
+            .sort((a, b) => (titleOrder[a.title as keyof typeof titleOrder] || 99) - (titleOrder[b.title as keyof typeof titleOrder] || 99))
+            .map((pos) => (
+              <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                  <div class="flex-1">
+                    <div class="flex items-center gap-3 mb-2">
+                      <h3 class="text-xl font-semibold text-clr-green">{pos.title}</h3>
+                      <span class="px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">ARB</span>
+                    </div>
+                    <p class="text-lg text-gray-800 font-medium mb-1">{pos.name || pos.email}</p>
+                    {pos.phone && (
+                      <p class="text-gray-600 flex items-center gap-2">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+                        </svg>
+                        {pos.phone}
+                      </p>
+                    )}
+                    <p class="text-sm text-gray-500 mt-2">
+                      Term started: {new Date(pos.start_date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+        </div>
+      )}
+    </section>
+
+    <!-- Administrators -->
+    <section class="mb-10">
+      <h2 class="text-2xl font-heading font-semibold text-clr-green mb-6 flex items-center gap-3">
+        <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+        System Administrators
+      </h2>
+
+      {adminUsers.length === 0 ? (
+        <p class="text-gray-500 p-6 bg-gray-50 rounded-xl">No administrators currently assigned.</p>
+      ) : (
+        <div class="grid gap-4">
+          {adminUsers.map((admin) => (
+            <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+              <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                <div class="flex-1">
+                  <div class="flex items-center gap-3 mb-2">
+                    <h3 class="text-xl font-semibold text-clr-green">Administrator</h3>
+                    <span class="px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">Admin</span>
+                  </div>
+                  <p class="text-lg text-gray-800 font-medium mb-1">{admin.name || admin.email}</p>
+                  {admin.phone && (
+                    <p class="text-gray-600 flex items-center gap-2">
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+                      </svg>
+                      {admin.phone}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+
+    <!-- Footer Note -->
+    <div class="bg-gray-50 rounded-xl p-6 text-sm text-gray-600">
+      <p class="mb-2">
+        <strong>Note:</strong> Board members, ARB committee members, and administrators are required to have their contact information listed per HOA governance requirements.
+      </p>
+      <p>
+        This directory is updated automatically as positions change. If you notice any errors, please contact <a href="mailto:board@clrhoa.com" class="text-clr-green underline hover:text-clr-green/80">board@clrhoa.com</a>.
+      </p>
+    </div>
+  </PortalPage>
+</PortalLayout>


### PR DESCRIPTION
Closes #313

## Summary

Adds a member-only leadership directory page displaying current board members, ARB committee members, and system administrators with their titles and contact information.

## Problem

Members need an easy way to see who currently serves in leadership positions (board, ARB, admins) and how to contact them, while understanding that official communication should go through board@clrhoa.com and arb@clrhoa.com.

## Solution

Created `/portal/leadership` page that:
- Displays current board positions from the `board_positions` table
- Shows ARB committee members
- Lists system administrators
- Provides contact details (name, phone, term start date)
- Prominently displays official contact emails

## Implementation Details

**New File:**
- `src/pages/portal/leadership.astro` - Member-only leadership directory page

**Updated Files:**
- `src/lib/menu-db.ts` - Added "Leadership" menu item (position 6, after Directory)

**Data Sources:**
- `getCurrentPositions()` from `board-positions-db.ts` - Board/ARB positions
- `getMemberByEmail()` from `members-db.ts` - Contact details
- Direct query for admin users from `users` table

**Page Sections:**
1. **Contact Notice** - Blue callout with board@clrhoa.com and arb@clrhoa.com
2. **Board of Directors** - President, VP, Secretary, Treasurer, Member at Large
3. **ARB Committee** - ARB Chair, ARB Members
4. **System Administrators** - Admin role users

**Display Features:**
- Hierarchical ordering (President → VP → Secretary → Treasurer → Member at Large → ARB Chair → ARB Member)
- Color-coded badges (Green=Board, Purple=ARB, Red=Admin)
- Mobile-responsive card layout
- Shows term start date for board/ARB positions
- Phone numbers displayed with icon
- Empty state messages if no positions filled

## Florida HOA Compliance

Per Florida Statute 720.303(4), board member contact information is considered association records and should be available to members. This feature supports that requirement while keeping the information within the member portal (authentication required).

## Testing

✅ TypeScript build passes  
✅ Pre-commit hooks pass  

**Manual Test Plan:**
1. Log in as a member → navigate to "Leadership" in sidebar
2. Verify all three sections display correctly (Board, ARB, Admins)
3. Verify contact details show for users with phone numbers
4. Verify empty state messages if no positions filled
5. Test mobile responsive layout
6. Verify prominent email contact notices display
7. Check hierarchical ordering of positions

## Screenshots

_Leadership directory showing Board of Directors, ARB Committee, and Administrators with contact details_

## Menu Integration

Added "Leadership" to the default portal menu:
- **Position**: 6 (after "Directory")
- **Icon**: star
- **Label**: "Leadership"
- **Visible**: All authenticated members

## Benefits

- **Transparency**: Members can easily see current leadership
- **Accessibility**: Clear contact information readily available
- **Compliance**: Meets HOA governance requirements for board contact disclosure
- **Guidance**: Prominent notices direct members to official communication channels
- **Automatic**: Updates automatically as positions change in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)