### PR TITLE
fix: Convert form.action to string to prevent TypeError

### DIFF
--- a/src/pages/portal/arb-request/edit/[id].astro
+++ b/src/pages/portal/arb-request/edit/[id].astro
@@ -251,9 +251,12 @@ const selectedTypes = req.application_type ? req.application_type.split(',').map
       const addFilesError = document.getElementById('add-files-error');
 
       // Defensive: verify form action is correct (not corrupted)
-      if (form && form.action && !form.action.endsWith('/api/arb-update')) {
-        console.error('[ARB-EDIT] Form action is incorrect:', form.action, 'Expected: /api/arb-update');
-        form.action = '/api/arb-update';
+      if (form && form.action) {
+        var actionUrl = String(form.action);
+        if (!actionUrl.endsWith('/api/arb-update')) {
+          console.error('[ARB-EDIT] Form action is incorrect:', actionUrl, 'Expected: /api/arb-update');
+          form.action = '/api/arb-update';
+        }
       }
 
       // Defensive: verify requestId is a string


### PR DESCRIPTION
## Problem

Browser console shows:
```
Uncaught TypeError: form.action.endsWith is not a function
    at ARB-2026-0001:294:47
```

This error was introduced in PR #317's defensive validation. The `form.action` property doesn't always behave as a string type with an `endsWith` method, causing the script to crash.

**Critical Impact:** This error prevents the entire script from running, which means:
- File upload button event listener never gets attached
- Users cannot upload files to ARB requests
- No error message is shown to the user

## Root Cause

Line 254 was calling `form.action.endsWith('/api/arb-update')` directly, but `form.action` is not guaranteed to be a string type in all browser contexts.

## Fix

Convert `form.action` to a string using `String(form.action)` before calling `endsWith`.

```javascript
// Before (crashes):
if (form && form.action && !form.action.endsWith('/api/arb-update')) {

// After (works):
if (form && form.action) {
  var actionUrl = String(form.action);
  if (!actionUrl.endsWith('/api/arb-update')) {
```

## Testing

1. Open browser console (F12)
2. Navigate to ARB request edit page
3. Verify no TypeError is shown
4. Verify file upload button works
5. Upload a file and confirm it appears after page reload

Fixes #316