### PR TITLE
fix: Use getAttribute to avoid RadioNodeList shadowing form.action

### DIFF
--- a/src/pages/portal/arb-request/edit/[id].astro
+++ b/src/pages/portal/arb-request/edit/[id].astro
@@ -251,11 +251,12 @@ const selectedTypes = req.application_type ? req.application_type.split(',').map
       const addFilesError = document.getElementById('add-files-error');
 
       // Defensive: verify form action is correct (not corrupted)
-      if (form && form.action) {
-        var actionUrl = String(form.action);
-        if (!actionUrl.endsWith('/api/arb-update')) {
-          console.error('[ARB-EDIT] Form action is incorrect:', actionUrl, 'Expected: /api/arb-update');
-          form.action = '/api/arb-update';
+      // NOTE: Use getAttribute() because form.action can return RadioNodeList when buttons have name="action"
+      if (form) {
+        var actionAttr = form.getAttribute('action');
+        if (!actionAttr || !actionAttr.endsWith('/api/arb-update')) {
+          console.error('[ARB-EDIT] Form action is incorrect:', actionAttr, 'Expected: /api/arb-update');
+          form.setAttribute('action', '/api/arb-update');
         }
       }
 


### PR DESCRIPTION
## Problem

Console shows warning:
```
[ARB-EDIT] Form action is incorrect: [object RadioNodeList] Expected: /api/arb-update
```

## Root Cause

The submit buttons in the form have `name="action"`:
```html
<button type="submit" name="action" value="save">Save</button>
<button type="submit" name="action" value="save_and_submit">Save and submit</button>
```

When you access `form.action`, the browser returns the RadioNodeList of these named elements **instead of the form's action URL**. This is because named form elements shadow form properties with the same name.

So `form.action` returns `[object RadioNodeList]` instead of `"/api/arb-update"`.

## Fix

Use `getAttribute('action')` and `setAttribute('action')` to access the actual HTML attribute instead of the DOM property:

```javascript
// Before:
var actionUrl = String(form.action);  // Returns [object RadioNodeList]
form.action = '/api/arb-update';

// After:
var actionAttr = form.getAttribute('action');  // Returns the actual URL
form.setAttribute('action', '/api/arb-update');
```

## Impact

This is a defensive check, so the warning doesn't break functionality. But fixing it:
- Removes console noise
- Ensures the form action is validated correctly
- Makes the code more robust

## Testing

1. Open ARB request edit page
2. Check browser console
3. Verify no RadioNodeList warning appears

Closes #316