### PR TITLE
fix: Use getAttribute in fetch to avoid RadioNodeList (CRITICAL)

### DIFF
--- a/src/pages/portal/arb-request/edit/[id].astro
+++ b/src/pages/portal/arb-request/edit/[id].astro
@@ -300,7 +300,9 @@ const selectedTypes = req.application_type ? req.application_type.split(',').map
           }
 
           try {
-            const res = await fetch(form.action, { method: 'POST', body: formData });
+            // Use getAttribute to avoid RadioNodeList shadowing from name="action" buttons
+            const formAction = form.getAttribute('action') || '/api/arb-update';
+            const res = await fetch(formAction, { method: 'POST', body: formData });
             console.log('[ARB-EDIT] Update response status:', res.status, res.statusText);
             const data = await res.json().catch(function () {
               console.error('[ARB-EDIT] Failed to parse response JSON');


### PR DESCRIPTION
## Critical Bug

The form save is **still posting to the wrong URL**:
```
POST /portal/arb-request/edit/[object%20RadioNodeList]
Response: 302 redirect
```

Browser console:
```
[ARB-EDIT] Update response status: 200 
[ARB-EDIT] Failed to parse response JSON
[ARB-EDIT] Update response data: {}
[ARB-EDIT] Update failed: {status: 200, ok: true, success: undefined}
```

## Root Cause

PR #321 fixed the validation using `getAttribute`, but the **fetch itself** still uses the corrupted property:

```javascript
// Line 303 - WRONG:
const res = await fetch(form.action, { method: 'POST', body: formData });
```

When this executes, `form.action` returns the RadioNodeList (because buttons have `name="action"`), which gets stringified to `"[object RadioNodeList]"` and appended to the current page URL\!

## Fix

Use `getAttribute('action')` in the fetch call:

```javascript
// CORRECT:
const formAction = form.getAttribute('action') || '/api/arb-update';
const res = await fetch(formAction, { method: 'POST', body: formData });
```

## Impact

**Before this fix:** Form saves don't work - they POST to wrong URL and fail silently
**After this fix:** Form saves POST to `/api/arb-update` correctly

## Testing

1. Edit an ARB request
2. Make a change and click Save
3. Check browser console - should show:
   ```
   [ARB-EDIT] Update response status: 200
   [ARB-EDIT] Update response data: {success: true, message: "..."}
   ```
4. Check Cloudflare logs - should POST to `/api/arb-update`, not RadioNodeList URL

Reopens #316 (needs this final fix)