### PR TITLE
fix: Remove scroll bars from PDF print output

### DIFF
--- a/src/pages/portal/my-requests.astro
+++ b/src/pages/portal/my-requests.astro
@@ -402,6 +402,18 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
       header, .no-print, .request-summary, [role="status"] { display: none !important; }
       main > p:first-of-type { display: none !important; }
 
+      /* CRITICAL: Hide all scrollbars in print */
+      * {
+        overflow: visible !important;
+        -webkit-overflow-scrolling: auto !important;
+      }
+
+      *::-webkit-scrollbar {
+        display: none !important;
+        width: 0 !important;
+        height: 0 !important;
+      }
+
       /* Remove overflow and height constraints to prevent scroll bars */
       body, html {
         overflow: visible !important;
@@ -459,6 +471,18 @@ function formatApproval(arbEsign: string | null, esignTimestamp: string | null):
       /* Remove max-width constraints for better print layout */
       .max-w-5xl, .max-w-7xl, .max-w-4xl {
         max-width: none !important;
+      }
+
+      /* Override all Tailwind overflow classes */
+      .overflow-auto, .overflow-scroll, .overflow-x-auto, .overflow-y-auto,
+      .overflow-x-scroll, .overflow-y-scroll, .overflow-hidden {
+        overflow: visible !important;
+      }
+
+      /* Ensure all containers are visible */
+      div, section, article, aside {
+        overflow: visible !important;
+        max-height: none !important;
       }
     }
   </style>


### PR DESCRIPTION
## Problem

When printing "My ARB Requests" page to PDF, scroll bars appear in the print output, making the PDF look unprofessional.

## Root Cause

Some container elements have overflow styles (overflow-auto, overflow-hidden, etc.) that weren't being overridden in the print media query. Webkit scrollbars were also still visible.

## Fix

Added comprehensive print styles to eliminate all scroll bars:

1. **Universal overflow rule** - Set `overflow: visible !important` on all elements
2. **Hide webkit scrollbars** - Set `display: none` on `::-webkit-scrollbar`
3. **Override Tailwind classes** - Explicitly override all Tailwind overflow utility classes
4. **Container elements** - Ensure div, section, article, aside have visible overflow

## Changes

```css
@media print {
  /* Hide all scrollbars */
  * {
    overflow: visible !important;
  }

  *::-webkit-scrollbar {
    display: none !important;
  }

  /* Override Tailwind overflow classes */
  .overflow-auto, .overflow-scroll, .overflow-hidden {
    overflow: visible !important;
  }

  /* Ensure containers are visible */
  div, section, article, aside {
    overflow: visible !important;
  }
}
```

## Testing

1. Go to "My ARB Requests" page
2. Click "Print to PDF" on any request
3. Save as PDF
4. Open PDF - verify no scroll bars appear

## Impact

PDF output is now clean and professional with no scroll bars.