### PR TITLE
debug: Add logging to diagnose member role update issue

### DIFF
--- a/src/pages/api/members/index.ts
+++ b/src/pages/api/members/index.ts
@@ -248,6 +248,13 @@ export const PUT: APIRoute = async ({ request, locals, clientAddress }) => {
     });
   }
 
+  console.log('[MEMBERS-API] PUT request received:', {
+    email,
+    role: body.role,
+    name: body.name,
+    hasRoleField: 'role' in body,
+  });
+
   try {
     const member = await getMemberByEmail(db, email);
     if (!member) {
@@ -279,16 +286,35 @@ export const PUT: APIRoute = async ({ request, locals, clientAddress }) => {
 
     // Update user role in KV if role changed
     if (body.role && kv && VALID_ROLES.has(body.role.toLowerCase())) {
+      console.log('[MEMBERS-API] Updating KV role:', { email, role: body.role.toLowerCase() });
       await setLoginWhitelistRole(kv, email, body.role.toLowerCase());
     }
 
     // Update user record in users table if exists
     if (member.hasAccount && member.userId) {
       const role = body.role?.toLowerCase() || member.role || 'member';
-      await db
+      console.log('[MEMBERS-API] Updating users table:', {
+        userId: member.userId,
+        email,
+        oldRole: member.role,
+        newRole: role,
+        name: body.name?.trim() || member.name,
+      });
+      const result = await db
         .prepare('UPDATE users SET name = ?, role = ? WHERE id = ?')
         .bind(body.name?.trim() || member.name, role, member.userId)
         .run();
+      console.log('[MEMBERS-API] Update result:', {
+        success: result.success,
+        changes: result.meta?.changes,
+        rowsAffected: result.meta?.rows_written,
+      });
+    } else {
+      console.log('[MEMBERS-API] Skipping users table update:', {
+        email,
+        hasAccount: member.hasAccount,
+        userId: member.userId,
+      });
     }
 
     return new Response(


### PR DESCRIPTION
## Problem

When updating member roles in the Board Members page, the changes don't persist. The PUT request returns 200 OK, but after refreshing the page, the role is back to the old value.

## Logs Showing the Issue

```
PUT /api/members - status 200 (appears successful)
GET /api/members - status 200 (role hasn't changed)
```

## Possible Causes

1. **Users table update failing silently** - The UPDATE might not match any rows
2. **Missing account** - Member might not have a `users` table entry yet (only in KV whitelist)
3. **Role data not sent correctly** - The role field might not be in the request body
4. **KV/DB mismatch** - KV updates but DB doesn't, or vice versa

## Debugging Added

Added comprehensive console logging to track:

1. **Incoming request data**:
   ```javascript
   console.log('[MEMBERS-API] PUT request received:', { email, role, name, hasRoleField })
   ```

2. **KV whitelist update**:
   ```javascript
   console.log('[MEMBERS-API] Updating KV role:', { email, role })
   ```

3. **Users table update**:
   ```javascript
   console.log('[MEMBERS-API] Updating users table:', {
     userId, email, oldRole, newRole, name
   })
   console.log('[MEMBERS-API] Update result:', {
     success, changes, rowsAffected
   })
   ```

4. **Skipped updates**:
   ```javascript
   console.log('[MEMBERS-API] Skipping users table update:', {
     email, hasAccount, userId
   })
   ```

## Testing

1. Merge this PR
2. Go to Board Members page
3. Update a member's role
4. Check Cloudflare logs for `[MEMBERS-API]` entries
5. Share the logs to identify the issue

The logs will show exactly what's happening during the update.