### PR TITLE
fix: Create placeholder users record for members without accounts

### DIFF
--- a/src/pages/api/members/index.ts
+++ b/src/pages/api/members/index.ts
@@ -290,8 +290,9 @@ export const PUT: APIRoute = async ({ request, locals, clientAddress }) => {
       await setLoginWhitelistRole(kv, email, body.role.toLowerCase());
     }
 
-    // Update user record in users table if exists
+    // Update or create user record in users table
     if (member.hasAccount && member.userId) {
+      // User has account - update existing record
       const role = body.role?.toLowerCase() || member.role || 'member';
       console.log('[MEMBERS-API] Updating users table:', {
         userId: member.userId,
@@ -309,11 +310,38 @@ export const PUT: APIRoute = async ({ request, locals, clientAddress }) => {
         changes: result.meta?.changes,
         rowsAffected: result.meta?.rows_written,
       });
+    } else if (body.role || body.name) {
+      // User doesn't have account yet - create placeholder record so role is visible
+      const role = body.role?.toLowerCase() || 'member';
+      const name = body.name?.trim() || member.name || null;
+      console.log('[MEMBERS-API] Creating placeholder users record:', {
+        email,
+        role,
+        name,
+        status: 'pending',
+      });
+
+      // Generate a user ID
+      const userId = crypto.randomUUID();
+
+      const result = await db
+        .prepare(
+          `INSERT INTO users (id, email, name, role, status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'pending', datetime('now'), datetime('now'))`
+        )
+        .bind(userId, email, name, role)
+        .run();
+
+      console.log('[MEMBERS-API] Placeholder created:', {
+        success: result.success,
+        userId,
+      });
     } else {
       console.log('[MEMBERS-API] Skipping users table update:', {
         email,
         hasAccount: member.hasAccount,
         userId: member.userId,
+        reason: 'No role or name to update',
       });
     }
 


### PR DESCRIPTION
## Problem

Role changes don't persist for members who haven't set up their password yet.

**Root cause from logs:**
```
[MEMBERS-API] Skipping users table update: {
  email: "bethperque@gmail.com",
  hasAccount: false,
  userId: null
}
```

Members without accounts have:
- ✅ Entry in `owners` table (directory)
- ✅ Entry in KV whitelist (role stored)
- ❌ **No entry in `users` table**

When `listAllMembers()` queries the database, it reads from the `users` table. If there's no record there, the role appears as null/unchanged.

## Solution

When updating a member who doesn't have an account, **create a placeholder record** in the `users` table with:
- `status = 'pending'` (indicates account not activated)
- The new role and name
- A generated user ID

This makes the role immediately visible in the UI without requiring password setup first.

## Flow

**Before:**
1. Update member role → saves to KV only
2. `listAllMembers()` reads from `users` table → no record found
3. Role appears unchanged in UI ❌

**After:**
1. Update member role → saves to KV **and creates placeholder in users table**
2. `listAllMembers()` reads from `users` table → finds record with new role
3. Role shows correctly in UI ✅
4. When user sets password → record updates from 'pending' to 'active'

## Code Changes

```typescript
} else if (body.role || body.name) {
  // Create placeholder record for members without accounts
  const userId = crypto.randomUUID();
  await db.prepare(
    INSERT INTO users (id, email, name, role, status, ...)
    VALUES (?, ?, ?, ?, 'pending', ...)
  ).bind(userId, email, name, role).run();
}
```

## Testing

1. Go to Board Members page
2. Update role for a member who hasn't set up their password (like Beth Perque)
3. Save changes
4. Refresh page
5. ✅ Role should now persist and display correctly

Fixes the issue identified in PR #324 debug logs.