### PR TITLE
fix: Use correct column name 'created' in users INSERT

### DIFF
--- a/src/pages/api/members/index.ts
+++ b/src/pages/api/members/index.ts
@@ -326,8 +326,8 @@ export const PUT: APIRoute = async ({ request, locals, clientAddress }) => {
 
       const result = await db
         .prepare(
-          `INSERT INTO users (id, email, name, role, status, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 'pending', datetime('now'), datetime('now'))`
+          `INSERT INTO users (id, email, name, role, status, created)
+           VALUES (?, ?, ?, ?, 'pending', datetime('now'))`
         )
         .bind(userId, email, name, role)
         .run();


### PR DESCRIPTION
## Problem

Member role updates fail with 500 error:
```
Error: table users has no column named created_at: SQLITE_ERROR
```

## Root Cause

The placeholder users record INSERT statement (from PR #325) used wrong column names:
```sql
INSERT INTO users (..., created_at, updated_at)
VALUES (..., datetime('now'), datetime('now'))
```

But the actual users table schema has:
- ✅ `created` (not created_at)
- ✅ `updated_at` exists, but not needed for INSERT
- ❌ `created_at` doesn't exist

## Fix

```sql
-- Before (WRONG):
INSERT INTO users (..., created_at, updated_at)
VALUES (..., datetime('now'), datetime('now'))

-- After (CORRECT):
INSERT INTO users (..., created)
VALUES (..., datetime('now'))
```

## Testing

1. Go to Board Members page
2. Update a member's role who doesn't have an account (like Beth Perque)
3. Should succeed with 200 OK instead of 500 error

Fixes the regression introduced in PR #325.