### PR TITLE
fix: Use direct SQL to update owners.board_title from board positions

### DIFF
--- a/src/lib/board-positions-db.ts
+++ b/src/lib/board-positions-db.ts
@@ -4,7 +4,7 @@
  */
 
 import { generateId } from '../utils/id-generator.js';
-import { updateOwner, getOwnerByEmail } from './directory-db';
+import { getOwnerByEmail } from './directory-db';
 
 /**
  * Valid board and ARB titles
@@ -189,8 +189,8 @@ export async function assignBoardPosition(
       .bind(id, normalizedEmail, title, start, assignedBy)
       .run();
 
-    // Update owners.board_title for directory display
-    await updateOwner(db, owner.id, { board_title: title });
+    // Update owners.board_title for directory display (direct update to avoid fallback chain losing board_title)
+    await db.prepare('UPDATE owners SET board_title = ? WHERE id = ?').bind(title, owner.id).run();
 
     return { success: true };
   } catch (error) {
@@ -240,8 +240,8 @@ export async function endBoardPosition(
         .run();
     }
 
-    // Clear board_title in owners
-    await updateOwner(db, owner.id, { board_title: null });
+    // Clear board_title in owners (direct update to avoid fallback chain losing board_title)
+    await db.prepare('UPDATE owners SET board_title = NULL WHERE id = ?').bind(owner.id).run();
 
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary

- `assignBoardPosition` and `endBoardPosition` previously called `updateOwner()` to sync `owners.board_title`, but `updateOwner()` has a multi-level fallback chain that silently drops `board_title` when `lot_number` or `is_primary` columns are absent from the schema
- This caused board/ARB titles to never appear in the member directory (which reads `owners.board_title` directly), even though the Members management page showed them correctly (it joins `board_positions` at query time)
- Replaced both `updateOwner()` calls with direct `UPDATE owners SET board_title = ? WHERE id = ?` queries that always write the value regardless of schema variant
- Ran a one-time D1 sync query to backfill `owners.board_title` for the 8 existing members who had positions assigned

## Test plan

- [ ] Assign a board/ARB title to a member on `/portal/board/members`
- [ ] Confirm the title appears in the Title column on `/portal/directory`
- [ ] Remove a title and confirm it clears from the directory
- [ ] Confirm existing titles (synced via migration) show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)