### PR TITLE
fix: Add missing notice_posted_at/agenda_posted_at for compliance page 500

### DIFF
--- a/scripts/schema-03-features.sql
+++ b/scripts/schema-03-features.sql
@@ -198,6 +198,8 @@ CREATE TABLE IF NOT EXISTS meetings (
   location TEXT,
   agenda_r2_key TEXT,
   post_to_public_news INTEGER DEFAULT 0,  -- From schema-meetings-post-to-public-news.sql
+  notice_posted_at TEXT,                  -- When meeting notice was posted (§720.303 compliance)
+  agenda_posted_at TEXT,                  -- When agenda was posted (§720.303 compliance)
   created_by TEXT,
   created TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/meeting-compliance.ts
+++ b/src/lib/meeting-compliance.ts
@@ -87,19 +87,36 @@ export async function getUpcomingMeetingsWithCompliance(
   db: D1Database,
   limit = 10
 ): Promise<MeetingComplianceStatus[]> {
-  const { results } = await db
-    .prepare(
-      `SELECT id, title, datetime, notice_posted_at, agenda_posted_at, created
-       FROM meetings
-       WHERE datetime >= datetime('now')
-       ORDER BY datetime ASC
-       LIMIT ?`
-    )
-    .bind(limit)
-    .all<Meeting>();
+  try {
+    const { results } = await db
+      .prepare(
+        `SELECT id, title, datetime, notice_posted_at, agenda_posted_at, created
+         FROM meetings
+         WHERE datetime >= datetime('now')
+         ORDER BY datetime ASC
+         LIMIT ?`
+      )
+      .bind(limit)
+      .all<Meeting>();
 
-  const meetings = results ?? [];
-  return meetings.map(checkMeetingCompliance);
+    const meetings = results ?? [];
+    return meetings.map(checkMeetingCompliance);
+  } catch {
+    // Fallback if notice_posted_at / agenda_posted_at columns are missing (schema migration not yet run)
+    const { results } = await db
+      .prepare(
+        `SELECT id, title, datetime, NULL as notice_posted_at, NULL as agenda_posted_at, created
+         FROM meetings
+         WHERE datetime >= datetime('now')
+         ORDER BY datetime ASC
+         LIMIT ?`
+      )
+      .bind(limit)
+      .all<Meeting>();
+
+    const meetings = results ?? [];
+    return meetings.map(checkMeetingCompliance);
+  }
 }
 
 /**
@@ -110,20 +127,38 @@ export async function getRecentMeetingsWithCompliance(
   db: D1Database,
   limit = 10
 ): Promise<MeetingComplianceStatus[]> {
-  const { results } = await db
-    .prepare(
-      `SELECT id, title, datetime, notice_posted_at, agenda_posted_at, created
-       FROM meetings
-       WHERE datetime < datetime('now')
-         AND datetime >= datetime('now', '-90 days')
-       ORDER BY datetime DESC
-       LIMIT ?`
-    )
-    .bind(limit)
-    .all<Meeting>();
+  try {
+    const { results } = await db
+      .prepare(
+        `SELECT id, title, datetime, notice_posted_at, agenda_posted_at, created
+         FROM meetings
+         WHERE datetime < datetime('now')
+           AND datetime >= datetime('now', '-90 days')
+         ORDER BY datetime DESC
+         LIMIT ?`
+      )
+      .bind(limit)
+      .all<Meeting>();
 
-  const meetings = results ?? [];
-  return meetings.map(checkMeetingCompliance);
+    const meetings = results ?? [];
+    return meetings.map(checkMeetingCompliance);
+  } catch {
+    // Fallback if notice_posted_at / agenda_posted_at columns are missing
+    const { results } = await db
+      .prepare(
+        `SELECT id, title, datetime, NULL as notice_posted_at, NULL as agenda_posted_at, created
+         FROM meetings
+         WHERE datetime < datetime('now')
+           AND datetime >= datetime('now', '-90 days')
+         ORDER BY datetime DESC
+         LIMIT ?`
+      )
+      .bind(limit)
+      .all<Meeting>();
+
+    const meetings = results ?? [];
+    return meetings.map(checkMeetingCompliance);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #332

## Summary

- Added `notice_posted_at` and `agenda_posted_at` columns to the consolidated `schema-03-features.sql` so fresh DB setups include them
- Added try/catch fallback in `getUpcomingMeetingsWithCompliance` and `getRecentMeetingsWithCompliance` — if columns are missing the query falls back to `NULL` values instead of throwing a hard 500
- Columns were already applied to the live D1 database directly via `ALTER TABLE`

## Root cause

The compliance page called `getUpcomingMeetingsWithCompliance` which selected `notice_posted_at` from `meetings`. These columns existed in a legacy archive migration but were never applied to production, causing:
```
D1_ERROR: no such column: notice_posted_at
```

## Test plan

- [ ] Visit `/portal/board/compliance` — page loads without 500
- [ ] Upcoming meetings section renders (columns are NULL until populated via meetings management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)