### PR TITLE
feat: Allow board/admin to delete news posts

### DIFF
--- a/src/lib/news-items-db.ts
+++ b/src/lib/news-items-db.ts
@@ -158,6 +158,12 @@ export async function insertNewsItem(
   return id;
 }
 
+/** Hard-delete a news item by ID. Returns true if a row was deleted. */
+export async function deleteNewsItem(db: D1Database, id: string): Promise<boolean> {
+  const result = await db.prepare(`DELETE FROM news_items WHERE id = ?`).bind(id).run();
+  return (result.meta.changes ?? 0) > 0;
+}
+
 /** Append R2 keys to a news item's images. Returns new keys array. */
 export async function appendNewsItemImages(
   db: D1Database,

--- a/src/pages/api/news-items.astro
+++ b/src/pages/api/news-items.astro
@@ -5,8 +5,9 @@
  */
 export const prerender = false;
 
-import { isElevatedRole, getEffectiveRole } from '../../lib/auth';
-import { listPublicNewsItems, listAllNewsItems, insertNewsItem } from '../../lib/news-items-db';
+import { isElevatedRole, getEffectiveRole, isBoardOnly } from '../../lib/auth';
+import { listPublicNewsItems, listAllNewsItems, insertNewsItem, getNewsItemById, getNewsItemImageKeys, deleteNewsItem } from '../../lib/news-items-db';
+import { logAdminEvent } from '../../lib/audit-log';
 
 const runtime = Astro.locals.runtime;
 const env = runtime?.env;
@@ -78,6 +79,96 @@ if (Astro.request.method === 'POST') {
   }
   const id = await insertNewsItem(db, { title, body: bodyText, is_public: isPublic, show_on_portal: showOnPortal });
   return new Response(JSON.stringify({ success: true, id }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+if (Astro.request.method === 'DELETE') {
+  const user = Astro.locals.user;
+  const session = Astro.locals.session;
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  const effectiveRole = getEffectiveRole(session);
+  const isBoard = isBoardOnly(effectiveRole) || effectiveRole === 'admin';
+  if (!isBoard) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { id?: string; csrf_token?: string };
+  try {
+    body = await Astro.request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // CSRF check
+  const csrfToken = (session as any)?.csrfToken;
+  if (!body.csrf_token || body.csrf_token !== csrfToken) {
+    return new Response(JSON.stringify({ error: 'Invalid CSRF token' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const id = typeof body.id === 'string' ? body.id.trim() : '';
+  if (!id) {
+    return new Response(JSON.stringify({ error: 'id required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Fetch item before deletion for audit + image cleanup
+  const item = await getNewsItemById(db, id);
+  if (!item) {
+    return new Response(JSON.stringify({ error: 'News item not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const imageKeys = getNewsItemImageKeys(item);
+
+  // Delete from D1
+  const deleted = await deleteNewsItem(db, id);
+  if (!deleted) {
+    return new Response(JSON.stringify({ error: 'Delete failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Delete images from R2 (best-effort)
+  const r2 = env?.CLOURHOA_FILES as R2Bucket | undefined;
+  if (r2 && imageKeys.length > 0) {
+    await Promise.allSettled(imageKeys.map((key) => r2.delete(key)));
+  }
+
+  // Audit log
+  const actorEmail = user?.email ?? (session as any)?.email ?? 'unknown';
+  await logAdminEvent(db, {
+    eventType: 'news_item_deleted',
+    userId: actorEmail,
+    action: `Deleted news item "${item.title}"`,
+    resourceType: 'news_item',
+    resourceId: id,
+    details: { title: item.title, imageCount: imageKeys.length },
+    ipAddress: Astro.request.headers.get('cf-connecting-ip') ?? null,
+    outcome: 'success',
+  }).catch(() => {});
+
+  return new Response(JSON.stringify({ success: true }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/src/pages/portal/board/news.astro
+++ b/src/pages/portal/board/news.astro
@@ -149,9 +149,20 @@ function formatDate(s: string | null): string {
               <p class="text-base text-gray-500 mt-0.5">{formatDate(item.created_at)} · {placement}{imageCount > 0 ? ` · ${imageCount} photo${imageCount === 1 ? '' : 's'}` : ''}</p>
               <p class="text-base text-gray-600 mt-1 line-clamp-2">{item.body.slice(0, 150)}{item.body.length > 150 ? '…' : ''}</p>
             </div>
-            {item.is_public === 1 && (
-              <a href={`/news/item/${item.id}`} target="_blank" rel="noopener noreferrer" class="text-sm text-clr-orange hover:underline shrink-0">View on site →</a>
-            )}
+            <div class="flex items-center gap-3 shrink-0">
+              {item.is_public === 1 && (
+                <a href={`/news/item/${item.id}`} target="_blank" rel="noopener noreferrer" class="text-sm text-clr-orange hover:underline">View on site →</a>
+              )}
+              <button
+                type="button"
+                class="news-delete-btn text-sm text-red-600 hover:text-red-800 hover:underline"
+                data-id={item.id}
+                data-title={escapeHtml(item.title)}
+                aria-label={`Delete "${item.title}"`}
+              >
+                Delete
+              </button>
+            </div>
           </li>
         );})}
       </ul>
@@ -220,6 +231,45 @@ function formatDate(s: string | null): string {
           img.src = url;
         });
       }
+
+      // Delete handlers
+      document.querySelectorAll('.news-delete-btn').forEach(function (btn) {
+        btn.addEventListener('click', async function () {
+          const id = btn.getAttribute('data-id');
+          const title = btn.getAttribute('data-title') || 'this post';
+          if (!id) return;
+          if (!confirm('Delete "' + title + '"?\n\nThis cannot be undone. Any attached photos will also be removed.')) return;
+
+          btn.disabled = true;
+          btn.textContent = 'Deleting…';
+
+          try {
+            const res = await fetch('/api/news-items', {
+              method: 'DELETE',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'same-origin',
+              body: JSON.stringify({ id, csrf_token: getCsrf() }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.success) {
+              const li = btn.closest('li');
+              if (li) {
+                li.style.transition = 'opacity 0.2s';
+                li.style.opacity = '0';
+                setTimeout(() => li.remove(), 200);
+              }
+            } else {
+              alert(data.error || 'Delete failed. Please try again.');
+              btn.disabled = false;
+              btn.textContent = 'Delete';
+            }
+          } catch {
+            alert('Network error. Please try again.');
+            btn.disabled = false;
+            btn.textContent = 'Delete';
+          }
+        });
+      });
 
       form?.addEventListener('submit', async (e) => {
         e.preventDefault();


### PR DESCRIPTION
Closes #335
Closes #340

## Summary
- Board and admin users can now delete news posts from `/portal/board/news`
- Each post in the list shows a **Delete** button that triggers a browser `confirm()` dialog with the post title before proceeding
- On confirm, sends `DELETE /api/news-items` with CSRF token; the API verifies board/admin role, hard-deletes the row from D1, and best-effort deletes any attached R2 images
- Deleted row fades out in place without a page reload
- Action is written to the audit log (`eventType: news_item_deleted`, includes actor email, post title, image count)

## Test plan
- [ ] Log in as board/admin with elevation, navigate to `/portal/board/news`
- [ ] Click Delete on a post — confirm dialog shows the post title
- [ ] Click Cancel — nothing happens
- [ ] Click OK — row fades out, post no longer appears in portal or public news
- [ ] Verify attached images are gone from R2
- [ ] Check audit_logs table for `news_item_deleted` entry
- [ ] Confirm regular members have no Delete button and get 403 from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)