### PR TITLE
fix: Propagate assumed_role through all role context helpers (#341)

### DIFF
--- a/src/lib/board-context.ts
+++ b/src/lib/board-context.ts
@@ -82,6 +82,10 @@ export async function getAdminContext(astro: RoleContextAstro): Promise<GetRoleC
     sessionId: luciaSession.id,
     elevated_until: (luciaSession as any).elevated_until,
     csrfToken: (luciaSession as any).csrfToken,
+    // Propagate assumed_role so getEffectiveRole() returns the assumed role (board/arb) for admin/arb_board
+    assumed_role: (luciaSession as any).assumed_role,
+    assumed_at: (luciaSession as any).assumed_at,
+    assumed_until: (luciaSession as any).assumed_until,
   };
 
   const effectiveRole = getEffectiveRole(session);

--- a/src/lib/portal-context.ts
+++ b/src/lib/portal-context.ts
@@ -9,7 +9,7 @@
 
 import type { User, Session } from 'lucia';
 import { getUserEmail, getUserRole } from '../types/auth';
-import { isElevatedRole } from './auth/middleware';
+import { getEffectiveRole } from './auth';
 
 /** Env shape available to portal pages (DB, SESSION_SECRET, etc.). Explicit type so Astro.locals inference does not narrow to never. */
 export interface PortalEnv {
@@ -88,15 +88,17 @@ export async function getPortalContext(
         csrfToken: (luciaSession as any).csrfToken, // Use the CSRF token from ExtendedSession (set by middleware)
         createdAt: (luciaSession as any).created_at,
         fingerprint: (luciaSession as any).fingerprint,
+        // Propagate assumed_role so getEffectiveRole() returns the assumed role (board/arb) for admin/arb_board
+        assumed_role: (luciaSession as any).assumed_role,
+        assumed_at: (luciaSession as any).assumed_at,
+        assumed_until: (luciaSession as any).assumed_until,
       };
     }
   }
 
-  // Determine effective role based on PIM elevation
-  // User must have both: (1) elevated role, and (2) active elevation
-  const userRole = session?.role?.toLowerCase() || 'member';
-  const hasElevation = session && typeof session.elevated_until === 'number' && session.elevated_until > Date.now();
-  const effectiveRole = isElevatedRole(userRole) && hasElevation ? userRole : 'member';
+  // Determine effective role using getEffectiveRole() which handles PIM elevation and assumed roles
+  // (e.g. admin assuming board role gets effectiveRole = 'board')
+  const effectiveRole = getEffectiveRole(session);
 
   return {
     env,


### PR DESCRIPTION
## Summary

- **Root cause**: `getAdminContext`, `getBoardContext`, `getArbContext`, and `getPortalContext` all built `SessionPayload` from the Lucia session without copying `assumed_role`, `assumed_at`, or `assumed_until`. Since `getEffectiveRole()` relies on those fields to detect an active role assumption, it always returned the raw DB role (`'admin'`) instead of the assumed role (`'board'`/`'arb'`).
- **Effect**: An admin who assumed the board role via PIM was immediately redirected back to the admin landing zone when visiting `/portal/board/assessments` or any member-facing page. Elevated board/ARB users were similarly blocked from member portal pages (meetings, feedback, library).
- **Fix**: Added `assumed_role`, `assumed_at`, `assumed_until` to the session payload in all four context helpers. In `portal-context.ts` the old inline effectiveRole calculation (which didn't account for assumed roles at all) was replaced with `getEffectiveRole(session)`.

Closes #341

## Test plan
- [ ] Log in as admin, request elevated access, assume board role
- [ ] Verify `/portal/board/assessments` loads without redirect
- [ ] Verify member-facing pages (meetings, feedback, library) load correctly under assumed board role
- [ ] Verify elevated ARB user can access ARB pages
- [ ] Verify non-elevated users still get redirected to member dashboard as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)