### PR TITLE
fix: Change Member Portal links to /portal/dashboard

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -85,7 +85,7 @@ export function resourcesByCategory(): Record<ResourceCategory, ResourceLink[]> 
 
 /** Footer "Quick Links" column. */
 export const footerQuickLinks: NavLink[] = [
-  { label: 'Member Portal', href: '/portal' },
+  { label: 'Member Portal', href: '/portal/dashboard' },
   { label: 'Documents', href: '/documents' },
   { label: 'Dues & Payment', href: '/dues' },
   { label: 'Board & Committees', href: '/board' },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -189,7 +189,7 @@ const resourcesByCategory = getResourcesByCategory();
 
             <!-- Nav CTAs -->
             <a
-              href="/portal"
+              href="/portal/dashboard"
               class="ml-2 bg-clr-green hover:brightness-110 text-white px-4 py-2 rounded-lg font-semibold text-sm shadow-md hover:shadow-lg transition-all no-print"
             >
               Member Portal
@@ -204,7 +204,7 @@ const resourcesByCategory = getResourcesByCategory();
           <div class="flex items-center gap-2">
             <!-- Member Portal Button (Mobile header) -->
             <a
-              href="/portal"
+              href="/portal/dashboard"
               class="md:hidden bg-clr-green hover:brightness-110 text-white px-3 py-2 rounded-lg font-semibold text-xs shadow-md hover:shadow-lg transition-all no-print"
             >
               Portal
@@ -269,7 +269,7 @@ const resourcesByCategory = getResourcesByCategory();
           ))}
 
           <div class="border-t border-gray-200 pt-3 mt-1 space-y-1">
-            <a href="/portal" class="block text-lg font-semibold transition-colors py-3 px-2 rounded-lg bg-clr-green/10 text-clr-green hover:bg-clr-green/20">
+            <a href="/portal/dashboard" class="block text-lg font-semibold transition-colors py-3 px-2 rounded-lg bg-clr-green/10 text-clr-green hover:bg-clr-green/20">
               Member Portal
             </a>
             <a href="/contact" class={`block text-lg font-medium transition-colors py-3 px-2 rounded-lg ${isActive('/contact') ? 'bg-clr-beige/30 text-clr-green font-semibold' : 'text-gray-700 hover:bg-clr-beige/20 hover:text-clr-green'}`}>


### PR DESCRIPTION
## Summary

`/portal` has no `index.astro` so it 404s. Updated all three Member Portal links (desktop nav button, mobile header button, mobile menu link) and the footer Quick Links entry to point to `/portal/dashboard` instead. Middleware redirects unauthenticated users to login from there.

## Test plan
- [ ] Clicking "Member Portal" on desktop nav goes to dashboard (or login if not authenticated)
- [ ] Clicking "Portal" on mobile header goes to dashboard (or login)
- [ ] Mobile menu "Member Portal" link works
- [ ] Footer "Member Portal" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)